### PR TITLE
feat: add ai filter flow

### DIFF
--- a/content/filter-bar/_components/active-filters.tsx
+++ b/content/filter-bar/_components/active-filters.tsx
@@ -23,7 +23,6 @@ interface ActiveFiltersProps<TData> {
   strategy: FilterStrategy;
   entityName?: string;
   aiGenerating?: boolean;
-  aiPendingColumnIds?: string[];
 }
 
 export function ActiveFilters<TData>({
@@ -33,42 +32,10 @@ export function ActiveFilters<TData>({
   strategy,
   entityName,
   aiGenerating,
-  aiPendingColumnIds,
 }: ActiveFiltersProps<TData>) {
-  const pendingIds = aiPendingColumnIds ?? [];
-  const pendingIdSet = useMemo(
-    () => new Set(pendingIds),
-    [pendingIds],
-  );
-
-  const pendingItems = pendingIds.map((columnId) => {
-    const filter = filters.find((item) => item.columnId === columnId);
-
-    if (filter && filter.values) {
-      const column = getColumn(columns, columnId);
-      return (
-        <ActiveFilter
-          key={`active-filter-${filter.columnId}`}
-          filter={filter}
-          column={column}
-          actions={actions}
-          strategy={strategy}
-          entityName={entityName}
-        />
-      );
-    }
-
-    return <ActiveFilterSkeleton key={`ai-skeleton-${columnId}`} />;
-  });
-
-  const remainingFilters = filters.filter(
-    (filter) => !pendingIdSet.has(filter.columnId),
-  );
-
   return (
     <>
-      {aiGenerating && pendingItems}
-      {remainingFilters.map((filter) => {
+      {filters.map((filter) => {
         const id = filter.columnId;
 
         const column = getColumn(columns, id);
@@ -87,6 +54,7 @@ export function ActiveFilters<TData>({
           />
         );
       })}
+      {aiGenerating && <ActiveFilterSkeleton />}
     </>
   );
 }

--- a/content/filter-bar/_components/data-table-filter.tsx
+++ b/content/filter-bar/_components/data-table-filter.tsx
@@ -40,11 +40,10 @@ export function DataTableFilter<TData>({
       ),
     [columns],
   );
-  const { aiGenerating, pendingColumnIds, handleAiFilterSubmit } =
-    useAiFilterSimulation({
-      visibleOptionColumns,
-      actions,
-    });
+  const { aiGenerating, handleAiFilterSubmit } = useAiFilterSimulation({
+    visibleOptionColumns,
+    actions,
+  });
 
   const selectorProps = {
     columns,
@@ -67,7 +66,6 @@ export function DataTableFilter<TData>({
             strategy={strategy}
             entityName={entityName}
             aiGenerating={aiGenerating}
-            aiPendingColumnIds={pendingColumnIds}
           />
           <FilterActions hasFilters={filters.length > 0} actions={actions} />
         </ActiveFiltersMobileContainer>
@@ -86,7 +84,6 @@ export function DataTableFilter<TData>({
           strategy={strategy}
           entityName={entityName}
           aiGenerating={aiGenerating}
-          aiPendingColumnIds={pendingColumnIds}
         />
         <FilterActions hasFilters={filters.length > 0} actions={actions} />
       </div>

--- a/content/filter-bar/_components/filter-selector.tsx
+++ b/content/filter-bar/_components/filter-selector.tsx
@@ -110,10 +110,31 @@ function __FilterSelector<TData>({
     [onAIFilterSubmit],
   );
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        const prompt = aiPromptRef.current?.value.trim();
+        if (!prompt || !onAIFilterSubmit) return;
+
+        onAIFilterSubmit(prompt);
+        setOpen(false);
+        setMode("list");
+        if (aiPromptRef.current) {
+          aiPromptRef.current.value = "";
+        }
+      }
+    },
+    [onAIFilterSubmit],
+  );
+
   const content = useMemo(
     () =>
       mode === "ai" ? (
-        <form className="flex w-[280px] flex-col gap-3 p-3" onSubmit={handleAiSubmit}>
+        <form
+          className="flex w-[280px] flex-col gap-3 p-3"
+          onSubmit={handleAiSubmit}
+        >
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
@@ -130,18 +151,25 @@ function __FilterSelector<TData>({
               AI Filter
             </div>
           </div>
-          <Textarea
-            ref={aiPromptRef}
-            placeholder="Describe what you're looking for..."
-            className="min-h-[120px] resize-none text-sm"
-          />
-          <Button
-            type="submit"
-            disabled={aiGenerating}
-            className="w-full"
-          >
-            {aiGenerating ? "Generating..." : "Generate filters"}
-          </Button>
+          <div className="relative">
+            <Textarea
+              ref={aiPromptRef}
+              placeholder="Describe what you're looking for..."
+              className="min-h-[120px] resize-none text-sm"
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+            <Button
+              variant="secondary"
+              size="sm"
+              className="absolute right-2 bottom-2 h-7 gap-1 px-2 text-xs"
+              loading={aiGenerating}
+              type="submit"
+            >
+              <span>⌘</span>
+              <kbd>Generate filters</kbd>
+            </Button>
+          </div>
         </form>
       ) : property && column && column.type !== "boolean" ? (
         <div className="flex flex-col">


### PR DESCRIPTION
## Summary
- add an ai filter option that captures a prompt inside the filter selector
- manage temporary skeleton placeholders and random filter injection while the prompt "generates"
- surface ai generation placeholders alongside existing filters on both desktop and mobile layouts

## Testing
- pnpm lint *(fails: existing lint errors in unrelated packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6f357a908323ad88c27738248b43