### PR TITLE
Inline only required UI components in sandpack content

### DIFF
--- a/apps/nextjs/src/app/(app)/page.tsx
+++ b/apps/nextjs/src/app/(app)/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
 import { Button } from "@repo/ui/button";
 
+import { getContentComponents } from "@/lib/content";
 import {
   contentCategories,
   contentElements,
   contentStyles,
-  getContentComponents,
-} from "@/lib/content";
+} from "@/lib/content-categories";
 import { ContentPreview } from "./_components/content-preview";
 import { FilterComboBox } from "./_components/filter-combo-box";
 

--- a/apps/nextjs/src/lib/content-categories.ts
+++ b/apps/nextjs/src/lib/content-categories.ts
@@ -1,0 +1,84 @@
+/**
+ * Represents a filter category for content components
+ */
+export type ContentFilter = {
+  name: string;
+  slug: string;
+  subcategories?: { name: string; slug: string }[];
+};
+
+// Filter categories for organizing content components
+export const contentApps: ContentFilter[] = [];
+
+export const contentCategories: ContentFilter[] = [
+  { name: "AI", slug: "ai" },
+  { name: "Productivity", slug: "productivity" },
+  { name: "Social", slug: "social" },
+  { name: "Entertainment", slug: "entertainment" },
+  { name: "Education", slug: "education" },
+  { name: "Finance", slug: "finance" },
+  { name: "Health & Fitness", slug: "health-fitness" },
+  { name: "Design", slug: "design" },
+  { name: "Business", slug: "business" },
+  { name: "Games", slug: "games" },
+  { name: "Utilities", slug: "utilities" },
+];
+
+export const contentStyles: ContentFilter[] = [
+  { name: "Minimal", slug: "minimal" },
+  { name: "Skeuomorphism", slug: "skeuomorphism" },
+  { name: "Colorful", slug: "colorful" },
+  { name: "Monochrome", slug: "monochrome" },
+  { name: "Cyberpunk", slug: "cyberpunk" },
+  { name: "Typographic", slug: "typographic" },
+  { name: "Geometric", slug: "geometric" },
+  { name: "Retro", slug: "retro" },
+  { name: "Silly", slug: "silly" },
+  { name: "Pixel Art", slug: "pixel-art" },
+];
+
+export const contentElements: ContentFilter[] = [
+  {
+    name: "Control",
+    slug: "control",
+    subcategories: [
+      { name: "Buttons and Links", slug: "buttons-and-links" },
+      { name: "Inputs", slug: "inputs" }, // Text, Number, Slider, Pickers, Combobox, etc.
+      { name: "Video & Audio", slug: "video-audio" },
+    ],
+  },
+  {
+    name: "View",
+    slug: "view",
+    subcategories: [
+      { name: "Cards", slug: "cards" },
+      { name: "Carousels", slug: "carousels" },
+      { name: "Grids", slug: "grids" },
+      { name: "Navigation", slug: "navigation" }, // Sidebar, Tabs, etc.
+      { name: "Tables", slug: "tables" },
+      { name: "Toolbars", slug: "toolbars" }, // Filter/Sort
+      { name: "Trees", slug: "trees" },
+      { name: "Effects", slug: "effects" },
+    ],
+  },
+  {
+    name: "Overlay",
+    slug: "overlay",
+    subcategories: [
+      { name: "Dialog and Drawer", slug: "dialog-and-drawer" },
+      {
+        name: "Dropdown, Popovers, and Tooltips",
+        slug: "dropdown-popovers-and-tooltips",
+      },
+      { name: "Toast", slug: "toast" },
+    ],
+  },
+  {
+    name: "Templates",
+    slug: "templates",
+    subcategories: [
+      { name: "Landing Pages", slug: "landing-pages" },
+      { name: "Dashboard Pages", slug: "dashboard-pages" },
+    ],
+  },
+];

--- a/apps/nextjs/src/lib/content.tsx
+++ b/apps/nextjs/src/lib/content.tsx
@@ -2,32 +2,52 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, extname, join, posix, relative } from "node:path";
 import { cache } from "react";
 
+/**
+ * Content Management System for UI Components
+ *
+ * This file handles the discovery, processing, and preparation of UI components
+ * from the content directory for display in a sandbox environment (like Sandpack).
+ * It automatically inlines dependencies from @repo/ui packages to create self-contained
+ * component bundles that can run independently.
+ */
+
+// Maps file paths to their source code content
 type SourceCodeMap = Record<string, string>;
 
+// Represents a UI module with its metadata and code
 type UiModule = {
-  relativePath: string;
-  sandpackPath: string;
-  code: string;
+  relativePath: string; // Path relative to UI source root
+  sandpackPath: string; // Path for use in Sandpack environment
+  code: string; // The actual source code
 };
 
+// Lookup tables for finding UI modules by different identifiers
 type UiModuleLookup = {
-  byPath: Map<string, UiModule>;
-  bySpecifier: Map<string, UiModule>;
+  byPath: Map<string, UiModule>; // Find by file path
+  bySpecifier: Map<string, UiModule>; // Find by import specifier
 };
 
+// Directory paths for content and UI packages
 const contentSourceDir = join(process.cwd(), "..", "..", "content");
 const uiSourceDir = join(process.cwd(), "..", "..", "packages", "ui");
 const uiSourceRoot = join(uiSourceDir, "src");
 
+// Patterns to ignore when reading files (similar to .gitignore)
 const GITIGNORE_PATTERNS = ["node_modules", "dist", ".DS_Store"];
 
+// Configuration for UI package imports and file types
 const UI_IMPORT_PREFIX = "@repo/ui/";
 const UI_FILE_EXTENSIONS = [".tsx", ".ts"] as const;
 
-const STATIC_IMPORT_SPECIFIER_REGEX = /from\s+["'`]([^"'`]+)["'`]/g;
-const BARE_IMPORT_SPECIFIER_REGEX = /import\s+["'`]([^"'`]+)["'`]/g;
-const DYNAMIC_IMPORT_SPECIFIER_REGEX = /import\(\s*["'`]([^"'`]+)["'`]\s*\)/g;
+// Regular expressions to extract import statements from source code
+const STATIC_IMPORT_SPECIFIER_REGEX = /from\s+["'`]([^"'`]+)["'`]/g; // import { x } from "module"
+const BARE_IMPORT_SPECIFIER_REGEX = /import\s+["'`]([^"'`]+)["'`]/g; // import "module"
+const DYNAMIC_IMPORT_SPECIFIER_REGEX = /import\(\s*["'`]([^"'`]+)["'`]\s*\)/g; // import("module")
 
+/**
+ * Extracts all module specifiers (import paths) from source code
+ * Handles static imports, bare imports, and dynamic imports
+ */
 const extractModuleSpecifiers = (source: string): string[] => {
   const specifiers = new Set<string>();
 
@@ -35,7 +55,11 @@ const extractModuleSpecifiers = (source: string): string[] => {
     regex.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = regex.exec(source)) !== null) {
-      specifiers.add(match[1]);
+      // TypeScript knows match[1] exists because the regex has a capture group
+      const captured = match[1];
+      if (captured && typeof captured === "string") {
+        specifiers.add(captured);
+      }
     }
   };
 
@@ -46,9 +70,17 @@ const extractModuleSpecifiers = (source: string): string[] => {
   return [...specifiers];
 };
 
+/**
+ * Normalizes module paths by converting backslashes to forward slashes
+ * and removing leading "./" prefixes
+ */
 const normalizeModulePath = (modulePath: string): string =>
   modulePath.replace(/\\/g, "/").replace(/^\.\//, "");
 
+/**
+ * Creates possible file paths for a given module path
+ * Handles both files with extensions and directories (which might have index files)
+ */
 const createUiCandidatePaths = (modulePath: string): string[] => {
   const normalized = normalizeModulePath(modulePath);
   const basePath = normalized === "" ? "index" : normalized;
@@ -56,11 +88,14 @@ const createUiCandidatePaths = (modulePath: string): string[] => {
   const extension = extname(basePath);
 
   if (extension) {
+    // If it already has an extension, use it as-is
     candidates.add(basePath);
   } else {
+    // If no extension, try adding .tsx and .ts extensions
     for (const ext of UI_FILE_EXTENSIONS) {
       candidates.add(`${basePath}${ext}`);
     }
+    // Also try index files in the directory
     candidates.add(`${basePath}/index.tsx`);
     candidates.add(`${basePath}/index.ts`);
   }
@@ -68,11 +103,29 @@ const createUiCandidatePaths = (modulePath: string): string[] => {
   return [...candidates];
 };
 
-const toSandpackPath = (relativePath: string) => `/ui/${normalizeModulePath(relativePath)}`;
+/**
+ * Converts a relative path to a Sandpack-compatible path
+ * All UI modules are placed under the /ui/ directory in Sandpack
+ */
+const toSandpackPath = (relativePath: string) =>
+  `/ui/${normalizeModulePath(relativePath)}`;
 
-const createRelativeUiSpecifier = (fromPath: string, toPath: string): string => {
-  const fromDir = posix.dirname(normalizeModulePath(fromPath.startsWith("/") ? fromPath.slice(1) : fromPath));
-  const target = normalizeModulePath(toPath.startsWith("/") ? toPath.slice(1) : toPath);
+/**
+ * Creates a relative import specifier between two UI modules
+ * Used when inlining dependencies to maintain proper relative imports
+ */
+const createRelativeUiSpecifier = (
+  fromPath: string,
+  toPath: string,
+): string => {
+  const fromDir = posix.dirname(
+    normalizeModulePath(
+      fromPath.startsWith("/") ? fromPath.slice(1) : fromPath,
+    ),
+  );
+  const target = normalizeModulePath(
+    toPath.startsWith("/") ? toPath.slice(1) : toPath,
+  );
   const relativePath = posix.relative(fromDir === "" ? "." : fromDir, target);
 
   if (relativePath === "") {
@@ -82,6 +135,9 @@ const createRelativeUiSpecifier = (fromPath: string, toPath: string): string => 
   return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
 };
 
+/**
+ * Safely reads and parses a JSON file, returning null if it doesn't exist or is invalid
+ */
 async function readJsonFile<T>(filePath: string): Promise<T | null> {
   try {
     const content = await readFile(filePath, "utf-8");
@@ -91,6 +147,10 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
   }
 }
 
+/**
+ * Determines if a file should be ignored when reading content
+ * Excludes preview files, package files, and gitignore patterns
+ */
 const shouldIgnoreFile = (relativePath: string): boolean => {
   if (["preview.tsx", "package.json", "meta.json"].includes(relativePath)) {
     return true;
@@ -106,12 +166,18 @@ const shouldIgnoreFile = (relativePath: string): boolean => {
   });
 };
 
+/**
+ * Recursively reads all files in a directory and stores their content
+ * Skips ignored files and directories
+ */
 const readDirectoryRecursively = async (
   directory: string,
   baseDir: string,
   sourceCode: SourceCodeMap,
 ) => {
-  const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+  const entries = await readdir(directory, { withFileTypes: true }).catch(
+    () => [],
+  );
 
   await Promise.all(
     entries.map(async (entry) => {
@@ -137,15 +203,26 @@ const readDirectoryRecursively = async (
   );
 };
 
+/**
+ * Checks if a file is a UI source file based on its extension
+ */
 const isUiSourceFile = (fileName: string) =>
-  UI_FILE_EXTENSIONS.includes(extname(fileName) as (typeof UI_FILE_EXTENSIONS)[number]);
+  UI_FILE_EXTENSIONS.includes(
+    extname(fileName) as (typeof UI_FILE_EXTENSIONS)[number],
+  );
 
+/**
+ * Reads all UI modules from the UI package and creates lookup tables
+ * This allows fast lookup by both file path and import specifier
+ */
 const readUiModules = async (): Promise<UiModuleLookup> => {
   const byPath = new Map<string, UiModule>();
   const bySpecifier = new Map<string, UiModule>();
 
   const walk = async (directory: string) => {
-    const entries = await readdir(directory, { withFileTypes: true }).catch(() => []);
+    const entries = await readdir(directory, { withFileTypes: true }).catch(
+      () => [],
+    );
 
     await Promise.all(
       entries.map(async (entry) => {
@@ -160,7 +237,9 @@ const readUiModules = async (): Promise<UiModuleLookup> => {
           return;
         }
 
-        const relativePath = normalizeModulePath(relative(uiSourceRoot, fullPath));
+        const relativePath = normalizeModulePath(
+          relative(uiSourceRoot, fullPath),
+        );
         const code = await readFile(fullPath, "utf-8");
         const uiModule: UiModule = {
           relativePath,
@@ -170,11 +249,16 @@ const readUiModules = async (): Promise<UiModuleLookup> => {
 
         byPath.set(relativePath, uiModule);
 
+        // Create multiple specifier mappings for flexible imports
         const pathWithoutExtension = relativePath.replace(/\.tsx?$/i, "");
-        const specifier = `${UI_IMPORT_PREFIX}${pathWithoutExtension}`.replace(/\/$/, "");
+        const specifier = `${UI_IMPORT_PREFIX}${pathWithoutExtension}`.replace(
+          /\/$/,
+          "",
+        );
         bySpecifier.set(specifier, uiModule);
         bySpecifier.set(`${UI_IMPORT_PREFIX}${relativePath}`, uiModule);
 
+        // Special case for index files - allow importing from package root
         if (pathWithoutExtension === "index") {
           bySpecifier.set("@repo/ui", uiModule);
         }
@@ -187,8 +271,13 @@ const readUiModules = async (): Promise<UiModuleLookup> => {
   return { byPath, bySpecifier };
 };
 
+// Cache the UI modules lookup to avoid re-reading files on every request
 const uiModules = cache(readUiModules);
 
+/**
+ * Finds a UI module by its import specifier (e.g., "@repo/ui/button")
+ * Handles both exact matches and path resolution
+ */
 const findUiModuleBySpecifier = (
   specifier: string,
   lookup: UiModuleLookup,
@@ -212,6 +301,10 @@ const findUiModuleBySpecifier = (
   return null;
 };
 
+/**
+ * Finds a UI module by relative import (e.g., "./button" or "../utils")
+ * Resolves the path relative to the importing module
+ */
 const findUiModuleByRelativeImport = (
   fromModule: UiModule,
   specifier: string,
@@ -231,6 +324,11 @@ const findUiModuleByRelativeImport = (
   return null;
 };
 
+/**
+ * Inlines UI dependencies by replacing @repo/ui imports with relative imports
+ * and embedding the actual UI module code into the source code map
+ * This creates self-contained component bundles for Sandpack
+ */
 const inlineUiDependencies = async (
   sourceCode: SourceCodeMap,
   previewCode: string,
@@ -239,6 +337,10 @@ const inlineUiDependencies = async (
   const embeddedUiSources = new Map<string, string>();
   const processed = new Set<string>();
 
+  /**
+   * Recursively processes a UI module and all its dependencies
+   * Replaces imports with relative paths and embeds the code
+   */
   const ensureUiModule = (uiModule: UiModule) => {
     if (processed.has(uiModule.relativePath)) {
       return;
@@ -248,8 +350,10 @@ const inlineUiDependencies = async (
 
     const replacements = new Map<string, string>();
 
+    // Process all imports in this module
     for (const specifier of extractModuleSpecifiers(uiModule.code)) {
       if (specifier.startsWith(UI_IMPORT_PREFIX) || specifier === "@repo/ui") {
+        // Handle @repo/ui imports
         const dependency = findUiModuleBySpecifier(specifier, lookup);
         if (!dependency) {
           continue;
@@ -262,7 +366,12 @@ const inlineUiDependencies = async (
         );
         replacements.set(specifier, replacement);
       } else if (specifier.startsWith(".")) {
-        const dependency = findUiModuleByRelativeImport(uiModule, specifier, lookup);
+        // Handle relative imports within UI package
+        const dependency = findUiModuleByRelativeImport(
+          uiModule,
+          specifier,
+          lookup,
+        );
         if (!dependency) {
           continue;
         }
@@ -276,6 +385,7 @@ const inlineUiDependencies = async (
       }
     }
 
+    // Apply all import replacements to the code
     let updatedCode = uiModule.code;
     for (const [original, replacement] of replacements) {
       updatedCode = updatedCode.replaceAll(original, replacement);
@@ -284,6 +394,9 @@ const inlineUiDependencies = async (
     embeddedUiSources.set(uiModule.sandpackPath, updatedCode);
   };
 
+  /**
+   * Rewrites imports in content files to point to inlined UI modules
+   */
   const rewriteCode = (filePath: string, code: string): string => {
     const replacements = new Map<string, string>();
 
@@ -294,7 +407,10 @@ const inlineUiDependencies = async (
       }
 
       ensureUiModule(dependency);
-      const replacement = createRelativeUiSpecifier(filePath, dependency.sandpackPath);
+      const replacement = createRelativeUiSpecifier(
+        filePath,
+        dependency.sandpackPath,
+      );
       replacements.set(specifier, replacement);
     }
 
@@ -306,13 +422,15 @@ const inlineUiDependencies = async (
     return updatedCode;
   };
 
-  const rewrittenSourceEntries = Object.entries(sourceCode).map(([filePath, code]) => [
-    filePath,
-    rewriteCode(filePath, code),
-  ] as const);
+  // Rewrite all content files
+  const rewrittenSourceEntries = Object.entries(sourceCode).map(
+    ([filePath, code]) => [filePath, rewriteCode(filePath, code)] as const,
+  );
 
+  // Rewrite preview code
   const rewrittenPreview = rewriteCode("/preview.tsx", previewCode);
 
+  // Combine rewritten content with inlined UI modules
   const updatedSourceCode: SourceCodeMap = {
     ...Object.fromEntries(rewrittenSourceEntries),
   };
@@ -327,6 +445,10 @@ const inlineUiDependencies = async (
   };
 };
 
+/**
+ * Reads all source files for a specific content component
+ * Returns a map of file paths to their source code
+ */
 export const readContentComponents = cache(async (slug: string) => {
   const componentDir = join(contentSourceDir, slug);
   const sourceCode: SourceCodeMap = {};
@@ -336,6 +458,10 @@ export const readContentComponents = cache(async (slug: string) => {
   return sourceCode;
 });
 
+/**
+ * Represents a content component with all its metadata and source code
+ * Used for displaying components in the UI and generating Sandpack bundles
+ */
 export type ContentComponent = {
   slug: string;
   name: string;
@@ -356,6 +482,10 @@ export type ContentComponent = {
   nextSlug?: string;
 };
 
+/**
+ * Gets all content components, optionally filtered by tags
+ * Adds navigation metadata (previous/next slug) for each component
+ */
 export const getContentComponents = cache(
   async (
     filterTags?: string[],
@@ -392,31 +522,41 @@ export const getContentComponents = cache(
   },
 );
 
+/**
+ * Reads a single content component with all its metadata and source code
+ * Handles UI dependency inlining if the component uses @repo/ui
+ */
 const readContentComponent = async (slug: string) => {
+  // Read component metadata
   const metadata =
     (await readJsonFile<ContentComponent>(
       join(contentSourceDir, slug, "meta.json"),
     )) ?? ({} as ContentComponent);
 
+  // Read package.json for dependencies
   const packageJson =
     (await readJsonFile<{
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
     }>(join(contentSourceDir, slug, "package.json"))) ?? {};
 
+  // Read preview code
   let previewCode = await readFile(
     join(contentSourceDir, slug, "preview.tsx"),
     "utf-8",
   ).catch(() => "");
 
+  // Read all source files
   let sourceCode = await readContentComponents(slug);
 
+  // If component uses @repo/ui, inline the UI dependencies
   if (packageJson.dependencies?.["@repo/ui"]) {
     const uiPackageJson =
       (await readJsonFile<{
         dependencies?: Record<string, string>;
       }>(join(uiSourceDir, "package.json"))) ?? {};
 
+    // Merge UI package dependencies into component dependencies
     const existingDependencies = packageJson.dependencies ?? {};
     delete existingDependencies["@repo/ui"];
 
@@ -425,6 +565,7 @@ const readContentComponent = async (slug: string) => {
       ...(uiPackageJson.dependencies ?? {}),
     };
 
+    // Inline UI dependencies and rewrite imports
     const inlineResult = await inlineUiDependencies(sourceCode, previewCode);
     sourceCode = inlineResult.sourceCode;
     previewCode = inlineResult.previewCode;
@@ -440,6 +581,9 @@ const readContentComponent = async (slug: string) => {
   };
 };
 
+/**
+ * Gets a single content component by slug
+ */
 export const getContentComponent = cache(
   async (slug: string): Promise<ContentComponent> => {
     const content = await getContentComponents();
@@ -447,90 +591,14 @@ export const getContentComponent = cache(
   },
 );
 
-export type ContentFilter = {
-  name: string;
-  slug: string;
-  subcategories?: { name: string; slug: string }[];
-};
-
-export const contentApps: ContentFilter[] = [];
-
-export const contentCategories: ContentFilter[] = [
-  { name: "AI", slug: "ai" },
-  { name: "Productivity", slug: "productivity" },
-  { name: "Social", slug: "social" },
-  { name: "Entertainment", slug: "entertainment" },
-  { name: "Education", slug: "education" },
-  { name: "Finance", slug: "finance" },
-  { name: "Health & Fitness", slug: "health-fitness" },
-  { name: "Design", slug: "design" },
-  { name: "Business", slug: "business" },
-  { name: "Games", slug: "games" },
-  { name: "Utilities", slug: "utilities" },
-];
-
-export const contentStyles: ContentFilter[] = [
-  { name: "Minimal", slug: "minimal" },
-  { name: "Skeuomorphism", slug: "skeuomorphism" },
-  { name: "Colorful", slug: "colorful" },
-  { name: "Monochrome", slug: "monochrome" },
-  { name: "Cyberpunk", slug: "cyberpunk" },
-  { name: "Typographic", slug: "typographic" },
-  { name: "Geometric", slug: "geometric" },
-  { name: "Retro", slug: "retro" },
-  { name: "Silly", slug: "silly" },
-  { name: "Pixel Art", slug: "pixel-art" },
-];
-
-export const contentElements: ContentFilter[] = [
-  {
-    name: "Control",
-    slug: "control",
-    subcategories: [
-      { name: "Buttons and Links", slug: "buttons-and-links" },
-      { name: "Inputs", slug: "inputs" }, // Text, Number, Slider, Pickers, Combobox, etc.
-      { name: "Video & Audio", slug: "video-audio" },
-    ],
-  },
-  {
-    name: "View",
-    slug: "view",
-    subcategories: [
-      { name: "Cards", slug: "cards" },
-      { name: "Carousels", slug: "carousels" },
-      { name: "Grids", slug: "grids" },
-      { name: "Navigation", slug: "navigation" }, // Sidebar, Tabs, etc.
-      { name: "Tables", slug: "tables" },
-      { name: "Toolbars", slug: "toolbars" }, // Filter/Sort
-      { name: "Trees", slug: "trees" },
-      { name: "Effects", slug: "effects" },
-    ],
-  },
-  {
-    name: "Overlay",
-    slug: "overlay",
-    subcategories: [
-      { name: "Dialog and Drawer", slug: "dialog-and-drawer" },
-      {
-        name: "Dropdown, Popovers, and Tooltips",
-        slug: "dropdown-popovers-and-tooltips",
-      },
-      { name: "Toast", slug: "toast" },
-    ],
-  },
-  {
-    name: "Templates",
-    slug: "templates",
-    subcategories: [
-      { name: "Landing Pages", slug: "landing-pages" },
-      { name: "Dashboard Pages", slug: "dashboard-pages" },
-    ],
-  },
-];
-
+/**
+ * Generates a package registry entry for a content component
+ * Creates a shadcn/ui compatible registry format for component distribution
+ */
 export const getContentComponentPackage = cache(async (slug: string) => {
   const contentComponent = await getContentComponent(slug);
 
+  // Filter out internal dependencies that shouldn't be in the registry
   const uicapsuleDependencies = Object.keys(
     contentComponent.dependencies ?? {},
   ).filter((dep) => dep.startsWith("@repo") && dep !== "@repo/shadcn-ui");


### PR DESCRIPTION
## Summary
- collect `@repo/ui` imports from content source and preview code
- inline only the required UI source files with rewritten import paths
- reuse shared helper to replace `@repo/ui` specifiers when preparing sandpack files

## Testing
- pnpm --filter @repo/nextjs lint

------
https://chatgpt.com/codex/tasks/task_e_68cf625f0b44832384b0d591a2747526