### PR TITLE
refactor: load search index client-side

### DIFF
--- a/apps/nextjs/src/lib/search/index-data.json
+++ b/apps/nextjs/src/lib/search/index-data.json
@@ -1,0 +1,369 @@
+{
+  "trending": [
+    {
+      "slug": "sphere",
+      "name": "3D Animated Sphere",
+      "href": "/ui/sphere",
+      "tags": []
+    },
+    {
+      "slug": "carousel-3d",
+      "name": "3D Carousel",
+      "href": "/ui/carousel-3d",
+      "tags": []
+    },
+    {
+      "slug": "ascii-renderer",
+      "name": "ASCII Renderer",
+      "description": "Take any 3D model and render it as ASCII art",
+      "href": "/ui/ascii-renderer",
+      "tags": []
+    },
+    {
+      "slug": "background-pixel-stars",
+      "name": "Background Pixel Stars",
+      "href": "/ui/background-pixel-stars",
+      "tags": []
+    },
+    {
+      "slug": "background-shapes",
+      "name": "Background Shapes",
+      "href": "/ui/background-shapes",
+      "tags": []
+    },
+    {
+      "slug": "emerald-template",
+      "name": "Emerald",
+      "href": "/ui/emerald-template",
+      "tags": [
+        "landing-pages"
+      ]
+    },
+    {
+      "slug": "expanding-header-menu",
+      "name": "Expanding Header Menu",
+      "href": "/ui/expanding-header-menu",
+      "tags": []
+    },
+    {
+      "slug": "filter-bar",
+      "name": "Filter Bar",
+      "href": "/ui/filter-bar",
+      "tags": []
+    },
+    {
+      "slug": "infinite-grid",
+      "name": "Infinite Grid",
+      "href": "/ui/infinite-grid",
+      "tags": []
+    },
+    {
+      "slug": "ios-volume-slider",
+      "name": "iOS Volume Slider",
+      "href": "/ui/ios-volume-slider",
+      "tags": []
+    },
+    {
+      "slug": "light-dark-toggle",
+      "name": "Light/Dark Toggle",
+      "href": "/ui/light-dark-toggle",
+      "tags": []
+    },
+    {
+      "slug": "like-button",
+      "name": "Like Button",
+      "description": "Twitter style like button",
+      "href": "/ui/like-button",
+      "tags": []
+    },
+    {
+      "slug": "line-chart",
+      "name": "Line Chart",
+      "href": "/ui/line-chart",
+      "tags": []
+    },
+    {
+      "slug": "radial-slider",
+      "name": "Radial Slider",
+      "href": "/ui/radial-slider",
+      "tags": []
+    },
+    {
+      "slug": "card-stack",
+      "name": "Scrollable Card Stack",
+      "description": "An infinite stack of cards placed with perspective one on top of another.",
+      "href": "/ui/card-stack",
+      "tags": []
+    },
+    {
+      "slug": "snail-timer",
+      "name": "Snail Timer",
+      "description": "Fastest countdown ever",
+      "href": "/ui/snail-timer",
+      "tags": []
+    },
+    {
+      "slug": "spreadsheet",
+      "name": "Spreadsheet",
+      "href": "/ui/spreadsheet",
+      "tags": []
+    },
+    {
+      "slug": "timeline",
+      "name": "Timeline",
+      "href": "/ui/timeline",
+      "tags": []
+    },
+    {
+      "slug": "tooltip-grid",
+      "name": "Tooltip Grid",
+      "description": "Tooltip with a direction aware pixel grid background animation",
+      "href": "/ui/tooltip-grid",
+      "tags": []
+    }
+  ],
+  "categories": [
+    {
+      "slug": "ai",
+      "name": "AI",
+      "href": "/?category=ai",
+      "count": 0
+    },
+    {
+      "slug": "business",
+      "name": "Business",
+      "href": "/?category=business",
+      "count": 0
+    },
+    {
+      "slug": "design",
+      "name": "Design",
+      "href": "/?category=design",
+      "count": 0
+    },
+    {
+      "slug": "education",
+      "name": "Education",
+      "href": "/?category=education",
+      "count": 0
+    },
+    {
+      "slug": "entertainment",
+      "name": "Entertainment",
+      "href": "/?category=entertainment",
+      "count": 0
+    },
+    {
+      "slug": "finance",
+      "name": "Finance",
+      "href": "/?category=finance",
+      "count": 0
+    },
+    {
+      "slug": "games",
+      "name": "Games",
+      "href": "/?category=games",
+      "count": 0
+    },
+    {
+      "slug": "health-fitness",
+      "name": "Health & Fitness",
+      "href": "/?category=health-fitness",
+      "count": 0
+    },
+    {
+      "slug": "productivity",
+      "name": "Productivity",
+      "href": "/?category=productivity",
+      "count": 0
+    },
+    {
+      "slug": "social",
+      "name": "Social",
+      "href": "/?category=social",
+      "count": 0
+    },
+    {
+      "slug": "utilities",
+      "name": "Utilities",
+      "href": "/?category=utilities",
+      "count": 0
+    }
+  ],
+  "sections": [
+    {
+      "slug": "buttons-and-links",
+      "name": "Buttons and Links",
+      "parent": "Control",
+      "href": "/?element=buttons-and-links",
+      "count": 0
+    },
+    {
+      "slug": "inputs",
+      "name": "Inputs",
+      "parent": "Control",
+      "href": "/?element=inputs",
+      "count": 0
+    },
+    {
+      "slug": "video-audio",
+      "name": "Video & Audio",
+      "parent": "Control",
+      "href": "/?element=video-audio",
+      "count": 0
+    },
+    {
+      "slug": "dialog-and-drawer",
+      "name": "Dialog and Drawer",
+      "parent": "Overlay",
+      "href": "/?element=dialog-and-drawer",
+      "count": 0
+    },
+    {
+      "slug": "dropdown-popovers-and-tooltips",
+      "name": "Dropdown, Popovers, and Tooltips",
+      "parent": "Overlay",
+      "href": "/?element=dropdown-popovers-and-tooltips",
+      "count": 0
+    },
+    {
+      "slug": "toast",
+      "name": "Toast",
+      "parent": "Overlay",
+      "href": "/?element=toast",
+      "count": 0
+    },
+    {
+      "slug": "dashboard-pages",
+      "name": "Dashboard Pages",
+      "parent": "Templates",
+      "href": "/?element=dashboard-pages",
+      "count": 0
+    },
+    {
+      "slug": "landing-pages",
+      "name": "Landing Pages",
+      "parent": "Templates",
+      "href": "/?element=landing-pages",
+      "count": 1
+    },
+    {
+      "slug": "cards",
+      "name": "Cards",
+      "parent": "View",
+      "href": "/?element=cards",
+      "count": 0
+    },
+    {
+      "slug": "carousels",
+      "name": "Carousels",
+      "parent": "View",
+      "href": "/?element=carousels",
+      "count": 0
+    },
+    {
+      "slug": "effects",
+      "name": "Effects",
+      "parent": "View",
+      "href": "/?element=effects",
+      "count": 0
+    },
+    {
+      "slug": "grids",
+      "name": "Grids",
+      "parent": "View",
+      "href": "/?element=grids",
+      "count": 0
+    },
+    {
+      "slug": "navigation",
+      "name": "Navigation",
+      "parent": "View",
+      "href": "/?element=navigation",
+      "count": 0
+    },
+    {
+      "slug": "tables",
+      "name": "Tables",
+      "parent": "View",
+      "href": "/?element=tables",
+      "count": 0
+    },
+    {
+      "slug": "toolbars",
+      "name": "Toolbars",
+      "parent": "View",
+      "href": "/?element=toolbars",
+      "count": 0
+    },
+    {
+      "slug": "trees",
+      "name": "Trees",
+      "parent": "View",
+      "href": "/?element=trees",
+      "count": 0
+    }
+  ],
+  "styles": [
+    {
+      "slug": "colorful",
+      "name": "Colorful",
+      "href": "/?style=colorful",
+      "count": 0
+    },
+    {
+      "slug": "cyberpunk",
+      "name": "Cyberpunk",
+      "href": "/?style=cyberpunk",
+      "count": 0
+    },
+    {
+      "slug": "geometric",
+      "name": "Geometric",
+      "href": "/?style=geometric",
+      "count": 0
+    },
+    {
+      "slug": "minimal",
+      "name": "Minimal",
+      "href": "/?style=minimal",
+      "count": 0
+    },
+    {
+      "slug": "monochrome",
+      "name": "Monochrome",
+      "href": "/?style=monochrome",
+      "count": 0
+    },
+    {
+      "slug": "pixel-art",
+      "name": "Pixel Art",
+      "href": "/?style=pixel-art",
+      "count": 0
+    },
+    {
+      "slug": "retro",
+      "name": "Retro",
+      "href": "/?style=retro",
+      "count": 0
+    },
+    {
+      "slug": "silly",
+      "name": "Silly",
+      "href": "/?style=silly",
+      "count": 0
+    },
+    {
+      "slug": "skeuomorphism",
+      "name": "Skeuomorphism",
+      "href": "/?style=skeuomorphism",
+      "count": 0
+    },
+    {
+      "slug": "typographic",
+      "name": "Typographic",
+      "href": "/?style=typographic",
+      "count": 0
+    }
+  ]
+}

--- a/apps/nextjs/src/lib/search/index.ts
+++ b/apps/nextjs/src/lib/search/index.ts
@@ -1,0 +1,19 @@
+import searchIndexData from "./index-data.json";
+
+import type {
+  SearchGroupKey,
+  SearchIndex,
+  SearchSectionItem,
+  SearchTaxonomyItem,
+  SearchTrendingItem,
+} from "./types";
+
+export const searchIndex = searchIndexData as SearchIndex;
+
+export type {
+  SearchGroupKey,
+  SearchIndex,
+  SearchSectionItem,
+  SearchTaxonomyItem,
+  SearchTrendingItem,
+};

--- a/apps/nextjs/src/lib/search/types.ts
+++ b/apps/nextjs/src/lib/search/types.ts
@@ -1,0 +1,27 @@
+export type SearchTrendingItem = {
+  slug: string;
+  name: string;
+  description?: string;
+  href: string;
+  tags: string[];
+};
+
+export type SearchTaxonomyItem = {
+  slug: string;
+  name: string;
+  href: string;
+  count: number;
+};
+
+export type SearchSectionItem = SearchTaxonomyItem & {
+  parent?: string;
+};
+
+export type SearchIndex = {
+  trending: SearchTrendingItem[];
+  categories: SearchTaxonomyItem[];
+  sections: SearchSectionItem[];
+  styles: SearchTaxonomyItem[];
+};
+
+export type SearchGroupKey = keyof SearchIndex;


### PR DESCRIPTION
## Summary
- remove the /api/search route and avoid fetching search data
- bundle a generated search index JSON file for the command palette
- update the search dialog to filter against the static index with local navigation counts

## Testing
- pnpm --filter @repo/nextjs lint

------
https://chatgpt.com/codex/tasks/task_e_68cf62afbbc8832380573d08e94f8c46