### PR TITLE
Add AI textarea component with shader glow

### DIFF
--- a/content/ai-textarea/meta.json
+++ b/content/ai-textarea/meta.json
@@ -1,6 +1,0 @@
-{
-  "name": "AI Textarea",
-  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/ai-textarea/cover.mp4",
-  "coverType": "video",
-  "tags": ["webgl", "shaders", "ui"]
-}

--- a/content/prompt-inout/meta.json
+++ b/content/prompt-inout/meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "Prompt Inout",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/prompt-inout/cover.mp4",
+  "coverType": "video",
+  "tags": ["webgl", "shaders", "ui"]
+}

--- a/content/prompt-inout/package.json
+++ b/content/prompt-inout/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uicapsule/ai-textarea",
+  "name": "@uicapsule/prompt-inout",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/content/prompt-inout/preview.tsx
+++ b/content/prompt-inout/preview.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
-import { AiTextarea } from "./ai-textarea";
+import { PromptInout } from "./prompt-inout";
 
 const Preview = () => {
   return (
     <div className="flex h-dvh w-dvw items-center justify-center bg-[#05060c]">
-      <AiTextarea />
+      <PromptInout />
     </div>
   );
 };

--- a/content/prompt-inout/prompt-inout.tsx
+++ b/content/prompt-inout/prompt-inout.tsx
@@ -292,11 +292,11 @@ const GlobalStyles = memo(() => (
     }
   }
 
-  .ai-textarea .sending {
+  .prompt-inout .sending {
     filter: drop-shadow(0 0 40px rgba(102, 140, 255, 0.35));
   }
 
-  .ai-textarea .sending input {
+  .prompt-inout .sending input {
     letter-spacing: 0.01em;
   }
 `}</style>
@@ -372,7 +372,7 @@ const ChevronDownIcon = () => (
   </svg>
 );
 
-export const AiTextarea: React.FC = () => {
+export const PromptInout: React.FC = () => {
   const [message, setMessage] = useState("");
   const [isSending, setIsSending] = useState(false);
   const glowTriggerRef = useRef<(() => void) | null>(null);
@@ -392,7 +392,7 @@ export const AiTextarea: React.FC = () => {
   };
 
   return (
-    <div className="ai-textarea relative flex min-h-[500px] items-center justify-center overflow-hidden rounded-[32px] bg-[#090b13] px-6 py-16 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+    <div className="prompt-inout relative flex min-h-[500px] items-center justify-center overflow-hidden rounded-[32px] bg-[#090b13] px-6 py-16 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
       <GlobalStyles />
       <GlowCanvas triggerRef={glowTriggerRef} />
       <BackgroundDecor />
@@ -450,4 +450,4 @@ export const AiTextarea: React.FC = () => {
   );
 };
 
-export default AiTextarea;
+export default PromptInout;


### PR DESCRIPTION
## Summary
- add an AI textarea content module with a WebGL shader glow that reacts to sending
- layer decorative interface elements and vertical text columns to match the reference layout
- register preview and metadata for the new content entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf8730de408323b9995f6365890636