### PR TITLE
Add haptic feedback to content clicks and prev/next nav

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "react-hook-form": "^7.75.0",
     "shiki": "^4.0.2",
     "superjson": "catalog:",
+    "web-haptics": "^0.0.6",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
+++ b/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
@@ -1,6 +1,9 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
 import { Badge } from "@repo/ui/components/badge";
+import { useWebHaptics } from "web-haptics/react";
 
 type ContentPreviewProps = {
   slug: string;
@@ -19,10 +22,12 @@ export const ContentPreview = ({
   coverUrl,
   coverType,
 }: ContentPreviewProps) => {
+  const { trigger } = useWebHaptics();
   return (
     <Link
       className="bg-background group flex flex-col justify-between gap-3 p-3 text-lg sm:p-6"
       href={`/ui/${slug}`}
+      onClick={() => trigger("selection")}
     >
       <div className="relative aspect-video overflow-hidden">
         {coverUrl && (

--- a/apps/web/src/app/(main)/(content)/_components/aside.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/aside.tsx
@@ -30,7 +30,6 @@ import {
   DownloadIcon,
   InfoIcon,
 } from "lucide-react";
-import { useWebHaptics } from "web-haptics/react";
 
 import type { ContentComponent } from "@repo/api/content/content-schema";
 import { CodePreview } from "./code-preview";
@@ -41,7 +40,6 @@ type AsideProps = {
 
 const Aside = ({ contentComponent }: AsideProps) => {
   const sectionClassname = "-mx-3 flex flex-col gap-2.5 border-t px-3 pt-3 pb-1";
-  const { trigger } = useWebHaptics();
 
   const handleInstallClick = () => {
     if (!isLocalContentComponent(contentComponent)) {
@@ -228,7 +226,6 @@ const Aside = ({ contentComponent }: AsideProps) => {
             size="icon"
             render={<Link href={`/ui/${contentComponent.previousSlug}`} />}
             nativeButton={false}
-            onClick={() => trigger("medium")}
           >
             <ArrowLeftIcon className="size-4" />
             <span className="sr-only">Previous</span>
@@ -242,7 +239,6 @@ const Aside = ({ contentComponent }: AsideProps) => {
             size="icon"
             render={<Link href={`/ui/${contentComponent.nextSlug}`} />}
             nativeButton={false}
-            onClick={() => trigger("medium")}
           >
             <span className="sr-only">Next</span>
             <ArrowRightIcon className="size-4" />

--- a/apps/web/src/app/(main)/(content)/_components/aside.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/aside.tsx
@@ -30,6 +30,7 @@ import {
   DownloadIcon,
   InfoIcon,
 } from "lucide-react";
+import { useWebHaptics } from "web-haptics/react";
 
 import type { ContentComponent } from "@repo/api/content/content-schema";
 import { CodePreview } from "./code-preview";
@@ -40,6 +41,7 @@ type AsideProps = {
 
 const Aside = ({ contentComponent }: AsideProps) => {
   const sectionClassname = "-mx-3 flex flex-col gap-2.5 border-t px-3 pt-3 pb-1";
+  const { trigger } = useWebHaptics();
 
   const handleInstallClick = () => {
     if (!isLocalContentComponent(contentComponent)) {
@@ -226,6 +228,7 @@ const Aside = ({ contentComponent }: AsideProps) => {
             size="icon"
             render={<Link href={`/ui/${contentComponent.previousSlug}`} />}
             nativeButton={false}
+            onClick={() => trigger("medium")}
           >
             <ArrowLeftIcon className="size-4" />
             <span className="sr-only">Previous</span>
@@ -239,6 +242,7 @@ const Aside = ({ contentComponent }: AsideProps) => {
             size="icon"
             render={<Link href={`/ui/${contentComponent.nextSlug}`} />}
             nativeButton={false}
+            onClick={() => trigger("medium")}
           >
             <span className="sr-only">Next</span>
             <ArrowRightIcon className="size-4" />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,7 +35,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "web-haptics": "^0.0.6"
   },
   "devDependencies": {
     "@kyh/tsconfig": "catalog:",

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@repo/ui/components/spinner";
 import { cn } from "@repo/ui/lib/utils";
 
 const buttonVariants = cva(
-  "group/button relative inline-flex shrink-0 items-center justify-center rounded-full bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button relative inline-flex shrink-0 items-center justify-center rounded-full bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px active:not-aria-[haspopup]:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -8,7 +8,7 @@ import { Spinner } from "@repo/ui/components/spinner";
 import { cn } from "@repo/ui/lib/utils";
 
 const buttonVariants = cva(
-  "group/button relative inline-flex shrink-0 items-center justify-center rounded-full bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px active:not-aria-[haspopup]:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/button relative inline-flex shrink-0 items-center justify-center rounded-full bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
+import { useWebHaptics } from "web-haptics/react";
 
 import { Spinner } from "@repo/ui/components/spinner";
 import { cn } from "@repo/ui/lib/utils";
@@ -64,13 +67,19 @@ function Button({
   loading,
   disabled,
   children,
+  onClick,
   ...props
 }: ButtonProps) {
+  const { trigger } = useWebHaptics();
   return (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, loading, className }))}
       disabled={loading || disabled}
+      onClick={(event) => {
+        trigger(variant === "destructive" ? "warning" : "selection");
+        onClick?.(event);
+      }}
       {...props}
     >
       {loading && (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1004,9 +1004,12 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: 'catalog:'
-        version: 4.4.3
+        version: 3.25.76
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -7425,9 +7428,6 @@ packages:
 
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
-
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -14475,8 +14475,6 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.2: {}
-
-  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
+      web-haptics:
+        specifier: ^0.0.6
+        version: 0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: 'catalog:'
         version: 4.4.2
@@ -1003,7 +1006,7 @@ importers:
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -3830,6 +3833,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@urql/core@5.2.0':
     resolution: {integrity: sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==}
@@ -7247,6 +7251,23 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-haptics@0.0.6:
+    resolution: {integrity: sha512-eCzcf1LDi20+Fr0x9V3OkX92k0gxEQXaHajmhXHitsnk6SxPeshv8TBtBRqxyst8HI1uf2FyFVE7QS3jo1gkrw==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+      svelte: '>=4'
+      vue: '>=3'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -7404,6 +7425,9 @@ packages:
 
   zod@4.4.2:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -11114,7 +11138,7 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
     optional: true
 
   dotenv-expand@12.0.3:
@@ -14316,6 +14340,11 @@ snapshots:
       defaults: 1.0.4
     optional: true
 
+  web-haptics@0.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   web-streams-polyfill@3.3.3: {}
 
   webgl-constants@1.1.1: {}
@@ -14446,6 +14475,8 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.2: {}
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary
- Adds `web-haptics` to `packages/ui` and wires `useWebHaptics()` into the shared `Button` so every button click fires a haptic on supported mobile browsers.
  - `variant="destructive"` → `warning` haptic
  - all other variants → `selection` haptic
  - any user-supplied `onClick` still runs after the trigger
- This covers prev/next nav arrows, filter dropdowns, drawer toggles, download/install actions, and any future buttons without per-call wiring.
- `ContentPreview` cards (which use `next/link`, not `Button`) get their own `selection` haptic on tap (`apps/web/src/app/(main)/(app)/_components/content-preview.tsx`).

`web-haptics` no-ops on devices without vibration support, so desktop is unaffected. `Button` is now `"use client"` — already how it's used in practice across the app.

## Test plan
- [ ] On a mobile device (iOS Safari / Android Chrome), open the gallery and tap a card — feel a selection tap before navigation.
- [ ] On the component detail page, tap the previous / next arrows — feel a selection tap.
- [ ] Tap a destructive button (if present) — feel a slightly stronger warning pattern.
- [ ] On desktop, confirm clicks still navigate normally with no console errors.

https://claude.ai/code/session_01We3JFxwzJTkTBv1xsYxkVo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds optional haptic triggers on click/tap and a minor active-state style tweak, with no changes to data handling or auth; primary risk is unexpected UX behavior on some devices/browsers.
> 
> **Overview**
> Adds `web-haptics` to the `apps/web` and `@repo/ui` packages and wires haptic feedback into shared click interactions.
> 
> `@repo/ui`’s `Button` now triggers a haptic on click (using `warning` for `variant="destructive"`, otherwise `selection`) while preserving any consumer-provided `onClick`, and slightly adjusts the active press animation from translate to scale.
> 
> Content cards (`ContentPreview`) now trigger a `selection` haptic on tap before navigating via `next/link`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 222159ff1c6a8cdd59fa7ff7bbb067e7ae480ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->