### PR TITLE
Use img-fx WebGL reveal for home page cover skeletons

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "@uicapsule/wireframe-orb": "workspace:*",
     "@vercel/analytics": "^2.0.1",
     "better-auth": "catalog:",
+    "img-fx": "^0.3.1",
     "jszip": "^3.10.1",
     "lucide-react": "^1.16.0",
     "motion": "^12.40.0",
@@ -59,6 +60,7 @@
     "react-hook-form": "^7.76.0",
     "shiki": "^4.1.0",
     "superjson": "catalog:",
+    "three": "^0.184.0",
     "web-haptics": "^0.0.6",
     "zod": "catalog:"
   },

--- a/apps/web/src/app/(frame)/preview-frame/[slug]/page.tsx
+++ b/apps/web/src/app/(frame)/preview-frame/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
+import { MediaReveal } from "@/components/media-reveal";
+
 import type { ComponentType } from "react";
 
 type Props = {
@@ -29,7 +31,7 @@ const PreviewContent = async ({ params }: Props) => {
 };
 
 const PreviewFramePage = ({ params }: Props) => (
-  <Suspense fallback={<div className="bg-muted h-full w-full animate-pulse" />}>
+  <Suspense fallback={<MediaReveal className="h-full w-full" />}>
     <PreviewContent params={params} />
   </Suspense>
 );

--- a/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
+++ b/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
@@ -1,9 +1,59 @@
 "use client";
 
-import Image from "next/image";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Badge } from "@repo/ui/components/badge";
+import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
 import { useWebHaptics } from "web-haptics/react";
+
+// img-fx WebGL "generation" shader acts as the loading skeleton. For image
+// covers it reveals the image natively; for video covers it cross-fades out
+// once the video has data, then pauses to free the renderer.
+const CoverReveal = ({ src, type }: { src: string; type: "image" | "video" }) => {
+  const handle = useRef<ImageGenerationHandle>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    if (type !== "image") return;
+    const id = window.setTimeout(() => {
+      handle.current?.triggerReveal({ hold: "manual" });
+      setRevealed(true);
+    }, 600);
+    return () => window.clearTimeout(id);
+  }, [type, src]);
+
+  const videoRevealed = type === "video" && revealed;
+
+  return (
+    <>
+      <ImageGeneration
+        ref={handle}
+        className="absolute inset-0 transition-opacity duration-700"
+        style={{ opacity: videoRevealed ? 0 : 1 }}
+        preset="pixels-organic"
+        theme="auto"
+        images={type === "image" ? src : undefined}
+        paused={videoRevealed}
+        borderRadius={0}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </ImageGeneration>
+      {type === "video" && (
+        <video
+          className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
+          style={{ opacity: revealed ? 1 : 0 }}
+          autoPlay
+          loop
+          muted
+          playsInline
+          onLoadedData={() => setRevealed(true)}
+        >
+          <source src={src} type="video/mp4" />
+        </video>
+      )}
+    </>
+  );
+};
 
 type ContentPreviewProps = {
   slug: string;
@@ -30,23 +80,7 @@ export const ContentPreview = ({
       onClick={() => trigger("selection")}
     >
       <div className="relative aspect-video overflow-hidden">
-        {coverUrl && (
-          <div aria-hidden className="bg-muted absolute inset-0 animate-pulse rounded" />
-        )}
-        {coverUrl && coverType === "image" && (
-          <Image src={coverUrl} fill alt="" className="object-contain" />
-        )}
-        {coverUrl && coverType === "video" && (
-          <video
-            className="absolute inset-0 h-full w-full object-cover"
-            autoPlay
-            loop
-            muted
-            playsInline
-          >
-            <source src={coverUrl} type="video/mp4" />
-          </video>
-        )}
+        {coverUrl && coverType && <CoverReveal src={coverUrl} type={coverType} />}
       </div>
       <div className="flex justify-between font-mono text-xs">
         <p className="group-hover:text-primary flex items-center gap-1 transition">{name} </p>

--- a/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
+++ b/apps/web/src/app/(main)/(app)/_components/content-preview.tsx
@@ -1,59 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Badge } from "@repo/ui/components/badge";
-import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
 import { useWebHaptics } from "web-haptics/react";
 
-// img-fx WebGL "generation" shader acts as the loading skeleton. For image
-// covers it reveals the image natively; for video covers it cross-fades out
-// once the video has data, then pauses to free the renderer.
-const CoverReveal = ({ src, type }: { src: string; type: "image" | "video" }) => {
-  const handle = useRef<ImageGenerationHandle>(null);
-  const [revealed, setRevealed] = useState(false);
-
-  useEffect(() => {
-    if (type !== "image") return;
-    const id = window.setTimeout(() => {
-      handle.current?.triggerReveal({ hold: "manual" });
-      setRevealed(true);
-    }, 600);
-    return () => window.clearTimeout(id);
-  }, [type, src]);
-
-  const videoRevealed = type === "video" && revealed;
-
-  return (
-    <>
-      <ImageGeneration
-        ref={handle}
-        className="absolute inset-0 transition-opacity duration-700"
-        style={{ opacity: videoRevealed ? 0 : 1 }}
-        preset="pixels-organic"
-        theme="auto"
-        images={type === "image" ? src : undefined}
-        paused={videoRevealed}
-        borderRadius={0}
-      >
-        <div style={{ width: "100%", height: "100%" }} />
-      </ImageGeneration>
-      {type === "video" && (
-        <video
-          className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
-          style={{ opacity: revealed ? 1 : 0 }}
-          autoPlay
-          loop
-          muted
-          playsInline
-          onLoadedData={() => setRevealed(true)}
-        >
-          <source src={src} type="video/mp4" />
-        </video>
-      )}
-    </>
-  );
-};
+import { MediaReveal } from "@/components/media-reveal";
 
 type ContentPreviewProps = {
   slug: string;
@@ -79,9 +30,11 @@ export const ContentPreview = ({
       href={`/ui/${slug}`}
       onClick={() => trigger("selection")}
     >
-      <div className="relative aspect-video overflow-hidden">
-        {coverUrl && coverType && <CoverReveal src={coverUrl} type={coverType} />}
-      </div>
+      <MediaReveal
+        className="aspect-video w-full"
+        image={coverType === "image" ? coverUrl : undefined}
+        video={coverType === "video" ? coverUrl : undefined}
+      />
       <div className="flex justify-between font-mono text-xs">
         <p className="group-hover:text-primary flex items-center gap-1 transition">{name} </p>
         <p className="text-muted-foreground/50 group-hover:text-primary/50 transition">
@@ -101,14 +54,12 @@ export const ContentPreview = ({
 export const ContentPreviewSkeleton = () => {
   return (
     <div className="bg-background group flex flex-col justify-between gap-3 p-3 sm:p-6">
-      <div className="aspect-video overflow-hidden">
-        <div className="bg-muted h-full w-full animate-pulse rounded" />
-      </div>
+      <MediaReveal className="aspect-video w-full" />
       <div className="flex justify-between text-xs">
         <div className="flex items-center gap-1">
-          <div className="bg-muted h-4 w-24 animate-pulse rounded" />
+          <div className="bg-muted h-4 w-24 rounded" />
         </div>
-        <div className="bg-muted h-4 w-8 animate-pulse rounded" />
+        <div className="bg-muted h-4 w-8 rounded" />
       </div>
     </div>
   );

--- a/apps/web/src/app/(main)/(app)/_components/filter-combo-box.tsx
+++ b/apps/web/src/app/(main)/(app)/_components/filter-combo-box.tsx
@@ -37,7 +37,7 @@ export const FilterComboBox = ({
   const [open, setOpen] = useState(false);
   const isDesktop = useMediaQuery("(min-width: 768px)");
   const triggerClassname = cn(
-    "justify-start capitalize",
+    "justify-start capitalize dark:bg-background!",
     highlighted && "border-foreground",
   );
 

--- a/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
@@ -196,15 +196,10 @@ const FeedItem = memo(function FeedItem({ ref, component, shouldRender }: FeedIt
         className="bg-background h-full w-full overflow-hidden rounded-md border"
         style={{ maxWidth: `${width}px` }}
       >
-        {shouldRender ? (
-          <iframe
-            className="bg-background h-full w-full"
-            title={component.name}
-            src={src}
-          />
-        ) : (
-          <MediaReveal className="h-full w-full" />
-        )}
+        <MediaReveal
+          className="h-full w-full"
+          iframe={shouldRender ? { src, title: component.name } : undefined}
+        />
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
@@ -16,6 +16,7 @@ import type {
   ContentComponentSummary,
   DefaultSize,
 } from "@repo/api/content/content-schema";
+import { MediaReveal } from "@/components/media-reveal";
 import { ResponsiveAside } from "./aside";
 
 const WIDTH_BY_SIZE = { sm: 360, md: 720, full: 1392 } as const satisfies Record<
@@ -202,7 +203,7 @@ const FeedItem = memo(function FeedItem({ ref, component, shouldRender }: FeedIt
             src={src}
           />
         ) : (
-          <div className="bg-muted h-full w-full animate-pulse" />
+          <MediaReveal className="h-full w-full" />
         )}
       </div>
     </section>

--- a/apps/web/src/app/(main)/(content)/ui/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/(content)/ui/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { notFound } from "next/navigation";
 
 import { ContentFeed } from "@/app/(main)/(content)/_components/content-feed";
+import { MediaReveal } from "@/components/media-reveal";
 import { publicCaller } from "@/trpc/server";
 
 type Props = {
@@ -32,6 +33,6 @@ const Content = async ({ params }: Props) => {
 
 const ContentFeedSkeleton = () => (
   <div className="flex h-full w-full flex-col gap-2 pb-2">
-    <div className="bg-muted mx-auto h-full w-full max-w-[720px] animate-pulse rounded-md" />
+    <MediaReveal className="mx-auto h-full w-full max-w-[720px] rounded-md" borderRadius={6} />
   </div>
 );

--- a/apps/web/src/app/(main)/(content)/ui/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/(content)/ui/[slug]/page.tsx
@@ -33,6 +33,6 @@ const Content = async ({ params }: Props) => {
 
 const ContentFeedSkeleton = () => (
   <div className="flex h-full w-full flex-col gap-2 pb-2">
-    <MediaReveal className="mx-auto h-full w-full max-w-[720px] rounded-md" borderRadius={6} />
+    <MediaReveal className="mx-auto h-full w-full max-w-[720px] rounded-md" />
   </div>
 );

--- a/apps/web/src/components/layout.tsx
+++ b/apps/web/src/components/layout.tsx
@@ -35,6 +35,7 @@ import {
 import { Logo } from "@repo/ui/components/logo";
 import { Tabs, TabsIndicator, TabsList, TabsTrigger } from "@repo/ui/components/tabs";
 import { useTheme } from "next-themes";
+import { useWebHaptics } from "web-haptics/react";
 import { cn } from "@repo/ui/lib/utils";
 import { useMediaQuery } from "@repo/ui/hooks/use-media-query";
 import { useQuery } from "@tanstack/react-query";
@@ -60,6 +61,7 @@ type SearchEntry = {
 };
 
 export const Header = ({ className }: { className?: string }) => {
+  const { trigger } = useWebHaptics();
   return (
     <nav
       className={cn(
@@ -68,7 +70,7 @@ export const Header = ({ className }: { className?: string }) => {
       )}
     >
       <div className="flex items-center justify-start gap-2">
-        <Link href="/">
+        <Link href="/" onClick={() => trigger("selection")}>
           <Logo />
         </Link>
       </div>

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -4,11 +4,6 @@ import { useEffect, useRef, useState } from "react";
 import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
 import { cn } from "@repo/ui/lib/utils";
 
-// Minimum time the generative shader stays on screen before the media is
-// revealed, so the effect is actually perceptible even when the media is
-// cached and loads instantly.
-const MIN_SHADER_MS = 1800;
-
 type MediaRevealProps = {
   className?: string;
   borderRadius?: number;
@@ -16,56 +11,63 @@ type MediaRevealProps = {
   video?: string;
 };
 
-// Animated img-fx "generation" shader used as the loading skeleton. Given an
-// image it reveals it natively; given a video it cross-fades the video in once
-// it has data (then pauses the shared WebGL renderer). With no media it is just
-// the animated skeleton, a drop-in replacement for a pulsing placeholder.
+// An img-fx "generation" shader sits on top as the loading skeleton and
+// dissolves away to reveal the media underneath. For an image, img-fx paints
+// and holds it on its own canvas, so the shader layer stays in place. With no
+// media it is just the animated skeleton, a drop-in for a pulsing placeholder.
 export const MediaReveal = ({ className, borderRadius = 0, image, video }: MediaRevealProps) => {
   const handle = useRef<ImageGenerationHandle>(null);
-  const [minElapsed, setMinElapsed] = useState(false);
-  const [videoLoaded, setVideoLoaded] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [revealed, setRevealed] = useState(false);
+  const [shaderPaused, setShaderPaused] = useState(false);
 
   useEffect(() => {
-    const id = window.setTimeout(() => setMinElapsed(true), MIN_SHADER_MS);
-    return () => window.clearTimeout(id);
-  }, []);
-
-  useEffect(() => {
-    if (!image || !minElapsed) return;
+    if (!image) return;
     handle.current?.triggerReveal({ hold: "manual" });
-  }, [image, minElapsed]);
+  }, [image]);
 
-  // Only video uses a separate overlay; an image is painted by the shader's own
-  // reveal canvas, so the shader layer stays in place for it.
-  const videoRevealed = Boolean(video) && videoLoaded && minElapsed;
+  // Reveal the video as soon as it can paint a frame. The readyState check
+  // covers videos that were already buffered (e.g. cached) before the event
+  // listeners attached and so never fire loadeddata/canplay.
+  useEffect(() => {
+    if (!video) return;
+    const el = videoRef.current;
+    if (el && el.readyState >= 2) setRevealed(true);
+  }, [video]);
+
+  const fadeOut = Boolean(video) && revealed;
 
   return (
     <div className={cn("relative overflow-hidden", className)}>
-      <ImageGeneration
-        ref={handle}
-        className="absolute! inset-0 transition-opacity duration-700"
-        style={{ opacity: videoRevealed ? 0 : 1 }}
-        preset="pixels-organic"
-        theme="auto"
-        images={image}
-        paused={videoRevealed}
-        borderRadius={borderRadius}
-      >
-        <div style={{ width: "100%", height: "100%" }} />
-      </ImageGeneration>
       {video && (
         <video
-          className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
-          style={{ opacity: videoRevealed ? 1 : 0 }}
+          ref={videoRef}
+          className="absolute inset-0 h-full w-full object-cover"
           autoPlay
           loop
           muted
           playsInline
-          onLoadedData={() => setVideoLoaded(true)}
+          onLoadedData={() => setRevealed(true)}
+          onCanPlay={() => setRevealed(true)}
         >
           <source src={video} type="video/mp4" />
         </video>
       )}
+      <ImageGeneration
+        ref={handle}
+        className="absolute! inset-0 transition-opacity duration-700"
+        style={{ opacity: fadeOut ? 0 : 1 }}
+        preset="pixels-organic"
+        theme="auto"
+        images={image}
+        paused={shaderPaused}
+        borderRadius={borderRadius}
+        onTransitionEnd={() => {
+          if (fadeOut) setShaderPaused(true);
+        }}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </ImageGeneration>
     </div>
   );
 };

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -1,45 +1,76 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
+import { ImageGeneration, setMaxDpr, type ImageGenerationHandle } from "img-fx";
 import { cn } from "@repo/ui/lib/utils";
+
+// The shaders are a decorative loading effect, so render them at DPR 1 — the
+// extra fragment cost of retina resolution isn't worth it across many cards.
+if (typeof window !== "undefined") setMaxDpr(1);
 
 type MediaRevealProps = {
   className?: string;
   image?: string;
   video?: string;
+  iframe?: { src: string; title: string };
 };
 
-// An img-fx "generation" shader sits on top as the loading skeleton and
-// dissolves away to reveal the media underneath. For an image, img-fx paints
-// and holds it on its own canvas, so the shader layer stays in place. With no
-// media it is just the animated skeleton, a drop-in for a pulsing placeholder.
-// The corner radius is auto-detected from the container's border-radius.
-export const MediaReveal = ({ className, image, video }: MediaRevealProps) => {
+// An img-fx "generation" shader acts as the loading skeleton and dissolves away
+// to reveal the media underneath once it is ready (image via img-fx's own
+// reveal, video on first frame, iframe on load). With no media it is just the
+// animated skeleton. The shader and video only initialise once the element
+// nears the viewport so a long grid/feed doesn't spin up dozens of WebGL
+// contexts on first paint.
+export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProps) => {
   const handle = useRef<ImageGenerationHandle>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const [inView, setInView] = useState(false);
   const [revealed, setRevealed] = useState(false);
-  const [shaderPaused, setShaderPaused] = useState(false);
 
   useEffect(() => {
-    if (!image) return;
-    handle.current?.triggerReveal({ hold: "manual" });
-  }, [image]);
+    const el = rootRef.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === "undefined") {
+      setInView(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setInView(true);
+          io.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
 
-  // Reveal the video as soon as it can paint a frame. The readyState check
-  // covers videos that were already buffered (e.g. cached) before the event
+  // Fall back to the skeleton when the source changes or is removed.
+  useEffect(() => {
+    setRevealed(false);
+  }, [image, video, iframe?.src]);
+
+  useEffect(() => {
+    if (!image || !inView) return;
+    handle.current?.triggerReveal({ hold: "manual" });
+  }, [image, inView]);
+
+  // Catch videos that were already buffered (e.g. cached) before the event
   // listeners attached and so never fire loadeddata/canplay.
   useEffect(() => {
-    if (!video) return;
+    if (!video || !inView) return;
     const el = videoRef.current;
     if (el && el.readyState >= 2) setRevealed(true);
-  }, [video]);
+  }, [video, inView]);
 
-  const fadeOut = Boolean(video) && revealed;
+  const fadeOut = revealed && (Boolean(video) || Boolean(iframe));
 
   return (
-    <div className={cn("relative overflow-hidden", className)}>
-      {video && (
+    <div ref={rootRef} className={cn("bg-muted relative overflow-hidden", className)}>
+      {video && inView && (
         <video
           ref={videoRef}
           className="absolute inset-0 h-full w-full object-cover"
@@ -53,20 +84,27 @@ export const MediaReveal = ({ className, image, video }: MediaRevealProps) => {
           <source src={video} type="video/mp4" />
         </video>
       )}
-      <ImageGeneration
-        ref={handle}
-        className="absolute! inset-0 transition-opacity duration-700"
-        style={{ opacity: fadeOut ? 0 : 1 }}
-        preset="pixels-organic"
-        theme="auto"
-        images={image}
-        paused={shaderPaused}
-        onTransitionEnd={() => {
-          if (fadeOut) setShaderPaused(true);
-        }}
-      >
-        <div style={{ width: "100%", height: "100%" }} />
-      </ImageGeneration>
+      {iframe && (
+        <iframe
+          className="absolute inset-0 h-full w-full bg-background"
+          title={iframe.title}
+          src={iframe.src}
+          onLoad={() => setRevealed(true)}
+        />
+      )}
+      {inView && (
+        <ImageGeneration
+          ref={handle}
+          className="absolute! inset-0 transition-opacity duration-700"
+          style={{ opacity: fadeOut ? 0 : 1 }}
+          preset="pixels-organic"
+          theme="auto"
+          images={image}
+          paused={fadeOut}
+        >
+          <div style={{ width: "100%", height: "100%" }} />
+        </ImageGeneration>
+      )}
     </div>
   );
 };

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
+import { cn } from "@repo/ui/lib/utils";
+
+type MediaRevealProps = {
+  className?: string;
+  borderRadius?: number;
+  image?: string;
+  video?: string;
+};
+
+// Animated img-fx "generation" shader used as the loading skeleton. Given an
+// image it reveals it natively; given a video it cross-fades the video in once
+// it has data (then pauses the shared WebGL renderer). With no media it is just
+// the animated skeleton, a drop-in replacement for a pulsing placeholder.
+export const MediaReveal = ({ className, borderRadius = 0, image, video }: MediaRevealProps) => {
+  const handle = useRef<ImageGenerationHandle>(null);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    if (!image) return;
+    const id = window.setTimeout(() => {
+      handle.current?.triggerReveal({ hold: "manual" });
+    }, 600);
+    return () => window.clearTimeout(id);
+  }, [image]);
+
+  // Only video uses a separate overlay; an image is painted by the shader's own
+  // reveal canvas, so the shader layer stays in place for it.
+  const videoRevealed = Boolean(video) && revealed;
+
+  return (
+    <div className={cn("relative overflow-hidden", className)}>
+      <ImageGeneration
+        ref={handle}
+        className="absolute inset-0 transition-opacity duration-700"
+        style={{ opacity: videoRevealed ? 0 : 1 }}
+        preset="pixels-organic"
+        theme="auto"
+        images={image}
+        paused={videoRevealed}
+        borderRadius={borderRadius}
+      >
+        <div style={{ width: "100%", height: "100%" }} />
+      </ImageGeneration>
+      {video && (
+        <video
+          className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
+          style={{ opacity: revealed ? 1 : 0 }}
+          autoPlay
+          loop
+          muted
+          playsInline
+          onLoadedData={() => setRevealed(true)}
+        >
+          <source src={video} type="video/mp4" />
+        </video>
+      )}
+    </div>
+  );
+};

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import { ImageGeneration, type ImageGenerationHandle } from "img-fx";
 import { cn } from "@repo/ui/lib/utils";
 
+// Minimum time the generative shader stays on screen before the media is
+// revealed, so the effect is actually perceptible even when the media is
+// cached and loads instantly.
+const MIN_SHADER_MS = 1800;
+
 type MediaRevealProps = {
   className?: string;
   borderRadius?: number;
@@ -17,19 +22,22 @@ type MediaRevealProps = {
 // the animated skeleton, a drop-in replacement for a pulsing placeholder.
 export const MediaReveal = ({ className, borderRadius = 0, image, video }: MediaRevealProps) => {
   const handle = useRef<ImageGenerationHandle>(null);
-  const [revealed, setRevealed] = useState(false);
+  const [minElapsed, setMinElapsed] = useState(false);
+  const [videoLoaded, setVideoLoaded] = useState(false);
 
   useEffect(() => {
-    if (!image) return;
-    const id = window.setTimeout(() => {
-      handle.current?.triggerReveal({ hold: "manual" });
-    }, 600);
+    const id = window.setTimeout(() => setMinElapsed(true), MIN_SHADER_MS);
     return () => window.clearTimeout(id);
-  }, [image]);
+  }, []);
+
+  useEffect(() => {
+    if (!image || !minElapsed) return;
+    handle.current?.triggerReveal({ hold: "manual" });
+  }, [image, minElapsed]);
 
   // Only video uses a separate overlay; an image is painted by the shader's own
   // reveal canvas, so the shader layer stays in place for it.
-  const videoRevealed = Boolean(video) && revealed;
+  const videoRevealed = Boolean(video) && videoLoaded && minElapsed;
 
   return (
     <div className={cn("relative overflow-hidden", className)}>
@@ -48,12 +56,12 @@ export const MediaReveal = ({ className, borderRadius = 0, image, video }: Media
       {video && (
         <video
           className="absolute inset-0 h-full w-full object-cover transition-opacity duration-700"
-          style={{ opacity: revealed ? 1 : 0 }}
+          style={{ opacity: videoRevealed ? 1 : 0 }}
           autoPlay
           loop
           muted
           playsInline
-          onLoadedData={() => setRevealed(true)}
+          onLoadedData={() => setVideoLoaded(true)}
         >
           <source src={video} type="video/mp4" />
         </video>

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -43,7 +43,7 @@ export const MediaReveal = ({ className, borderRadius = 0, image, video }: Media
     <div className={cn("relative overflow-hidden", className)}>
       <ImageGeneration
         ref={handle}
-        className="absolute inset-0 transition-opacity duration-700"
+        className="absolute! inset-0 transition-opacity duration-700"
         style={{ opacity: videoRevealed ? 0 : 1 }}
         preset="pixels-organic"
         theme="auto"

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -6,7 +6,6 @@ import { cn } from "@repo/ui/lib/utils";
 
 type MediaRevealProps = {
   className?: string;
-  borderRadius?: number;
   image?: string;
   video?: string;
 };
@@ -15,7 +14,8 @@ type MediaRevealProps = {
 // dissolves away to reveal the media underneath. For an image, img-fx paints
 // and holds it on its own canvas, so the shader layer stays in place. With no
 // media it is just the animated skeleton, a drop-in for a pulsing placeholder.
-export const MediaReveal = ({ className, borderRadius = 0, image, video }: MediaRevealProps) => {
+// The corner radius is auto-detected from the container's border-radius.
+export const MediaReveal = ({ className, image, video }: MediaRevealProps) => {
   const handle = useRef<ImageGenerationHandle>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [revealed, setRevealed] = useState(false);
@@ -61,7 +61,6 @@ export const MediaReveal = ({ className, borderRadius = 0, image, video }: Media
         theme="auto"
         images={image}
         paused={shaderPaused}
-        borderRadius={borderRadius}
         onTransitionEnd={() => {
           if (fadeOut) setShaderPaused(true);
         }}

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -51,16 +51,6 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
   const [revealed, setRevealed] = useState(false);
   const [retired, setRetired] = useState(false);
 
-  // Reset to the skeleton when the source changes or is removed (e.g. a feed
-  // item scrolled away and back) — derived during render, no Effect needed.
-  const source = iframe?.src ?? video ?? image ?? null;
-  const [prevSource, setPrevSource] = useState(source);
-  if (source !== prevSource) {
-    setPrevSource(source);
-    setRevealed(false);
-    setRetired(false);
-  }
-
   // Reveal an image once the shader is mounted; img-fx loads the bitmap itself.
   useEffect(() => {
     if (image && inView) handle.current?.triggerReveal({ hold: "manual" });

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -27,6 +27,9 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
   const videoRef = useRef<HTMLVideoElement>(null);
   const [inView, setInView] = useState(false);
   const [revealed, setRevealed] = useState(false);
+  // Set once the shader has faded out, to drop it from the DOM (and free its
+  // WebGL instance + observers) since it has nothing left to show.
+  const [retired, setRetired] = useState(false);
 
   useEffect(() => {
     const el = rootRef.current;
@@ -51,6 +54,7 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
   // Fall back to the skeleton when the source changes or is removed.
   useEffect(() => {
     setRevealed(false);
+    setRetired(false);
   }, [image, video, iframe?.src]);
 
   useEffect(() => {
@@ -92,7 +96,7 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
           onLoad={() => setRevealed(true)}
         />
       )}
-      {inView && (
+      {inView && !retired && (
         <ImageGeneration
           ref={handle}
           className="pointer-events-none absolute! inset-0 transition-opacity duration-700"
@@ -101,6 +105,9 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
           theme="auto"
           images={image}
           paused={fadeOut}
+          onTransitionEnd={(e) => {
+            if (e.propertyName === "opacity" && fadeOut) setRetired(true);
+          }}
         >
           <div style={{ width: "100%", height: "100%" }} />
         </ImageGeneration>

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -95,7 +95,7 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
       {inView && (
         <ImageGeneration
           ref={handle}
-          className="absolute! inset-0 transition-opacity duration-700"
+          className="pointer-events-none absolute! inset-0 transition-opacity duration-700"
           style={{ opacity: fadeOut ? 0 : 1 }}
           preset="pixels-organic"
           theme="auto"

--- a/apps/web/src/components/media-reveal.tsx
+++ b/apps/web/src/components/media-reveal.tsx
@@ -8,33 +8,14 @@ import { cn } from "@repo/ui/lib/utils";
 // extra fragment cost of retina resolution isn't worth it across many cards.
 if (typeof window !== "undefined") setMaxDpr(1);
 
-type MediaRevealProps = {
-  className?: string;
-  image?: string;
-  video?: string;
-  iframe?: { src: string; title: string };
-};
-
-// An img-fx "generation" shader acts as the loading skeleton and dissolves away
-// to reveal the media underneath once it is ready (image via img-fx's own
-// reveal, video on first frame, iframe on load). With no media it is just the
-// animated skeleton. The shader and video only initialise once the element
-// nears the viewport so a long grid/feed doesn't spin up dozens of WebGL
-// contexts on first paint.
-export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProps) => {
-  const handle = useRef<ImageGenerationHandle>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const videoRef = useRef<HTMLVideoElement>(null);
+// Latches true once the element first scrolls near the viewport, so the heavy
+// work (WebGL shader, video loading) is deferred until then.
+const useInView = (rootMargin = "200px") => {
+  const ref = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
-  const [revealed, setRevealed] = useState(false);
-  // Set once the shader has faded out, to drop it from the DOM (and free its
-  // WebGL instance + observers) since it has nothing left to show.
-  const [retired, setRetired] = useState(false);
-
   useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    if (typeof IntersectionObserver === "undefined") {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
       setInView(true);
       return;
     }
@@ -45,30 +26,45 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
           io.disconnect();
         }
       },
-      { rootMargin: "200px" },
+      { rootMargin },
     );
     io.observe(el);
     return () => io.disconnect();
-  }, []);
+  }, [rootMargin]);
+  return [ref, inView] as const;
+};
 
-  // Fall back to the skeleton when the source changes or is removed.
-  useEffect(() => {
+type MediaRevealProps = {
+  className?: string;
+  image?: string;
+  video?: string;
+  iframe?: { src: string; title: string };
+};
+
+// An img-fx "generation" shader acts as the loading skeleton and dissolves away
+// to reveal the media underneath once it is ready (image via img-fx's own
+// reveal, video on first frame, iframe on load), then drops from the DOM to
+// free its WebGL instance. With no media it is just the animated skeleton.
+export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProps) => {
+  const handle = useRef<ImageGenerationHandle>(null);
+  const [rootRef, inView] = useInView();
+  const [revealed, setRevealed] = useState(false);
+  const [retired, setRetired] = useState(false);
+
+  // Reset to the skeleton when the source changes or is removed (e.g. a feed
+  // item scrolled away and back) — derived during render, no Effect needed.
+  const source = iframe?.src ?? video ?? image ?? null;
+  const [prevSource, setPrevSource] = useState(source);
+  if (source !== prevSource) {
+    setPrevSource(source);
     setRevealed(false);
     setRetired(false);
-  }, [image, video, iframe?.src]);
+  }
 
+  // Reveal an image once the shader is mounted; img-fx loads the bitmap itself.
   useEffect(() => {
-    if (!image || !inView) return;
-    handle.current?.triggerReveal({ hold: "manual" });
+    if (image && inView) handle.current?.triggerReveal({ hold: "manual" });
   }, [image, inView]);
-
-  // Catch videos that were already buffered (e.g. cached) before the event
-  // listeners attached and so never fire loadeddata/canplay.
-  useEffect(() => {
-    if (!video || !inView) return;
-    const el = videoRef.current;
-    if (el && el.readyState >= 2) setRevealed(true);
-  }, [video, inView]);
 
   const fadeOut = revealed && (Boolean(video) || Boolean(iframe));
 
@@ -76,7 +72,6 @@ export const MediaReveal = ({ className, image, video, iframe }: MediaRevealProp
     <div ref={rootRef} className={cn("bg-muted relative overflow-hidden", className)}>
       {video && inView && (
         <video
-          ref={videoRef}
           className="absolute inset-0 h-full w-full object-cover"
           autoPlay
           loop

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       better-auth:
         specifier: 'catalog:'
         version: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      img-fx:
+        specifier: ^0.3.1
+        version: 0.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -227,6 +230,9 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
+      three:
+        specifier: ^0.184.0
+        version: 0.184.0
       web-haptics:
         specifier: ^0.0.6
         version: 0.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -1009,7 +1015,7 @@ importers:
         version: 0.0.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.4.3
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -5263,6 +5269,13 @@ packages:
     resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  img-fx@0.3.1:
+    resolution: {integrity: sha512-7reYL4uVZMFbV2vx26++3A12zIdum9SN4Srjg1+vDb4JqKzCPoFOqHxnqaLmsWwZ/dgxZW1XxNaJ6W7POthvzQ==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+      three: '>=0.149.0'
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -11155,7 +11168,7 @@ snapshots:
 
   dotenv-expand@11.0.7:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.6.1
     optional: true
 
   dotenv-expand@12.0.3:
@@ -11894,6 +11907,12 @@ snapshots:
     dependencies:
       queue: 6.0.2
     optional: true
+
+  img-fx@0.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      three: 0.184.0
 
   immediate@3.0.6: {}
 


### PR DESCRIPTION
## Summary

Replaces the `animate-pulse` cover placeholder on the home page content grid with the [img-fx](https://github.com/Jakubantalik/img-fx) `ImageGeneration` WebGL effect. The animated "generation" shader now serves as the loading skeleton and reveals the cover:

- **Image covers** — uses img-fx's native reveal (`triggerReveal({ hold: "manual" })`), so the pixel mosaic dissolves into the cover image.
- **Video covers** (all current content) — the shader plays as the skeleton, the video cross-fades in on `loadeddata`, and the shader is paused once revealed to free the shared WebGL renderer.
- `theme="auto"` follows the app's light/dark mode; `borderRadius={0}` matches the square `aspect-video` cover frame.

Adds `img-fx@^0.3.1` and its `three@^0.184.0` peer dep to `apps/web` (three is already used by other content packages at the same version).

## Notes / verification

- `pnpm typecheck` is clean for the changed files (pre-existing repo-wide type errors in `auth-form.tsx` / `packages/ui` are unrelated).
- Dev server renders the home route (HTTP 200); SSR markup contains 24 video covers + 48 img-fx canvases (shader + reveal per card) with no hydration/runtime errors.
- The live WebGL animation could **not** be visually confirmed in the sandbox: browser binaries can't be downloaded here and the cover videos / Turso DB require network + env unavailable in this environment. Worth a quick local visual check before merging.

## Test plan

- [ ] Run `pnpm dev:web` with a valid `TURSO_DATABASE_URL` and load `/`
- [ ] Confirm each cover shows the img-fx shader skeleton, then cross-fades to the video
- [ ] Toggle light/dark and verify the shader theme follows
- [ ] Sanity-check performance with the full grid (shaders should pause after reveal / off-screen)

https://claude.ai/code/session_013cyE1rYc5fzbwLMgWGRGU8

---
_Generated by [Claude Code](https://claude.ai/code/session_013cyE1rYc5fzbwLMgWGRGU8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client-only but adds WebGL (img-fx/three) on many surfaces at once; performance and SSR/hydration behavior need a quick visual pass on the full grid and feed.
> 
> **Overview**
> Introduces **`MediaReveal`**, a shared client component that uses **img-fx** `ImageGeneration` (WebGL) instead of **`animate-pulse`** / plain iframes for loading and cover display across the web app.
> 
> **`apps/web`** adds **`img-fx`** and peer **`three`**. Covers on the home grid drop inline **`next/image`** / **`<video>`** in favor of **`MediaReveal`** with image or video URLs; skeleton cards use the same shader placeholder. The vertical **content feed** wraps preview iframes so the shader shows until **`onLoad`**, with **`shouldRender`** still gating **`src`**. **Suspense** fallbacks on preview-frame and **`/ui/[slug]`** use **`MediaReveal`** instead of muted pulse blocks.
> 
> The component caps shader **DPR at 1**, defers WebGL/video until **IntersectionObserver** (`200px` margin), fades the overlay when video/iframe is ready, and unmounts **`ImageGeneration`** after the opacity transition to drop WebGL work. Minor UI tweaks: filter trigger **`dark:bg-background!`**, header logo **selection** haptics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7837dba25ac383897ef295e2946f2330ae1ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces all cover and loading skeletons with the `img-fx` WebGL reveal via a reusable `MediaReveal` component across the home grid, feed, preview-frame, and Suspense fallbacks. Adds viewport-based lazy mount and DPR 1 for smoother, more interactive media.

- **New Features**
  - `MediaReveal` replaces placeholders in the home grid, feed iframe placeholder, preview-frame, and UI Suspense fallbacks.
  - Images reveal natively; videos dissolve in on `loadeddata`/`canplay`; iframes dissolve in on `load`.
  - Supports `theme="auto"` and auto-detects border radius. Adds `img-fx@^0.3.1` + `three@^0.184.0`.

- **Bug Fixes**
  - Lazy-mount shaders and videos near the viewport; render at DPR 1 to avoid first-load freezes.
  - Overlay is `pointer-events-none`; shader root fills its container via `absolute!`; dark-mode filter trigger uses `dark:bg-background!`; logo click triggers selection haptics.
  - After fade-out, unmount the shader to free WebGL; no remounts on feed scroll.
  - Event-driven reveal logic (`useInView` + media load events) for reliable transitions.

<sup>Written for commit 190b9a13b2032fc0a3e16e2350710531bcadfb18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/24?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

