### PR TITLE
fix: filter-bar preview invisible in dark mode

### DIFF
--- a/content/filter-bar/preview.tsx
+++ b/content/filter-bar/preview.tsx
@@ -22,7 +22,7 @@ export default function Preview() {
   });
 
   return (
-    <div className="flex h-screen items-center bg-stone-100 p-10">
+    <div className="flex h-screen items-center bg-stone-100 p-10 dark:bg-stone-900">
       <DataTableFilter
         filters={filters}
         columns={columns}


### PR DESCRIPTION
Filter-bar showcase preview pinned `bg-stone-100` while the preview iframe inherits the system theme. In dark mode the component rendered with dark tokens (white text/borders) on a light bg — invisible. Added `dark:bg-stone-900`.

Verified in browser: dark mode shows trigger + popover, light mode unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a docs/preview-only wrapper; no runtime or data-path impact.
> 
> **Overview**
> Fixes the filter-bar **showcase preview** so it stays readable when the preview iframe follows **dark mode**.
> 
> The preview shell only used `bg-stone-100`, while `DataTableFilter` picks up dark theme tokens (light text/borders). That left dark UI on a light background. The wrapper now adds **`dark:bg-stone-900`** so the page background matches the component theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f2466faa64adaab3ae6f581af6876e6f9276ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the invisible filter-bar preview in dark mode by adding `dark:bg-stone-900` to the preview wrapper. The preview now matches the system theme and has proper contrast; light mode is unchanged.

<sup>Written for commit 0f2466faa64adaab3ae6f581af6876e6f9276ed1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

