### PR TITLE
feat: add `pnpm new:content` CLI to scaffold content components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,4 +37,5 @@ pnpm format           # Check formatting
 pnpm format:fix       # Fix formatting
 pnpm db:push          # Push local db schema
 pnpm db:push-remote   # Push to production Turso
+pnpm new:content <slug>  # Scaffold a new content component (content/ + web app dep)
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typecheck": "turbo run typecheck",
     "format": "oxfmt",
     "lint:fix": "oxlint --fix",
-    "format:fix": "oxfmt --write"
+    "format:fix": "oxfmt --write",
+    "new:content": "tsx scripts/new-content.ts"
   },
   "devDependencies": {
     "dotenv-cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "new:content": "tsx scripts/new-content.ts"
   },
   "devDependencies": {
+    "citty": "^0.2.2",
+    "consola": "^3.4.2",
     "dotenv-cli": "^11.0.0",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,12 @@ importers:
 
   .:
     devDependencies:
+      citty:
+        specifier: ^0.2.2
+        version: 0.2.2
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -196,7 +202,7 @@ importers:
         version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       img-fx:
         specifier: ^0.3.1
         version: 0.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(three@0.184.0)
@@ -890,7 +896,7 @@ importers:
         version: 11.17.0(typescript@6.0.3)
       better-auth:
         specifier: 'catalog:'
-        version: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: 'catalog:'
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -8247,7 +8253,7 @@ snapshots:
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       better-call: 1.3.5(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
@@ -10665,7 +10671,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.32: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.6(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.28.17)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)))
@@ -10914,8 +10920,7 @@ snapshots:
       consola: 3.4.2
     optional: true
 
-  citty@0.2.2:
-    optional: true
+  citty@0.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -11027,8 +11032,7 @@ snapshots:
       - supports-color
     optional: true
 
-  consola@3.4.2:
-    optional: true
+  consola@3.4.2: {}
 
   content-disposition@1.1.0: {}
 

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -13,7 +13,7 @@
  */
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -112,15 +112,16 @@ export default Preview;
 const componentTsx = (componentName: string, displayName: string) => `"use client";
 
 export const ${componentName} = () => {
-  return <div>${displayName}</div>;
+  return <div>{${JSON.stringify(displayName)}}</div>;
 };
 `;
 
 /**
  * Inserts the dependency in alphabetical position without re-sorting existing
- * keys, so unrelated lines never change.
+ * keys, so unrelated lines never change. Returns the previous file contents
+ * when a change was made, for rollback on failure.
  */
-const addWebDependency = async (slug: string) => {
+const addWebDependency = async (slug: string): Promise<string | null> => {
   const pkgName = `@uicapsule/${slug}`;
   const raw = await readFile(webPackageJsonPath, "utf-8");
   const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
@@ -128,7 +129,7 @@ const addWebDependency = async (slug: string) => {
 
   if (dependencies[pkgName]) {
     console.log(`- ${pkgName} already in apps/web/package.json, skipping`);
-    return;
+    return null;
   }
 
   const next: Record<string, string> = {};
@@ -145,6 +146,7 @@ const addWebDependency = async (slug: string) => {
   pkg.dependencies = next;
   await writeFile(webPackageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
   console.log(`- Added ${pkgName} to apps/web/package.json`);
+  return raw;
 };
 
 const main = async () => {
@@ -164,22 +166,33 @@ const main = async () => {
   const displayName = name ?? toTitleCase(slug);
   const componentName = toPascalCase(slug);
 
-  await mkdir(dir, { recursive: true });
-  await Promise.all([
-    writeFile(join(dir, "meta.json"), metaJson(displayName, description ?? "")),
-    writeFile(join(dir, "package.json"), packageJson(slug)),
-    writeFile(join(dir, "preview.tsx"), previewTsx(slug, componentName)),
-    writeFile(join(dir, `${slug}.tsx`), componentTsx(componentName, displayName)),
-  ]);
-  console.log(`- Created content/${slug}`);
+  let webPackageJsonBackup: string | null = null;
+  try {
+    await mkdir(dir, { recursive: true });
+    await Promise.all([
+      writeFile(join(dir, "meta.json"), metaJson(displayName, description ?? "")),
+      writeFile(join(dir, "package.json"), packageJson(slug)),
+      writeFile(join(dir, "preview.tsx"), previewTsx(slug, componentName)),
+      writeFile(join(dir, `${slug}.tsx`), componentTsx(componentName, displayName)),
+    ]);
+    console.log(`- Created content/${slug}`);
 
-  await addWebDependency(slug);
+    webPackageJsonBackup = await addWebDependency(slug);
 
-  if (install) {
-    console.log("- Running pnpm install...");
-    execSync("pnpm install", { cwd: repoRoot, stdio: "inherit" });
-  } else {
-    console.log("- Skipped pnpm install (--no-install)");
+    if (install) {
+      console.log("- Running pnpm install...");
+      execSync("pnpm install", { cwd: repoRoot, stdio: "inherit" });
+    } else {
+      console.log("- Skipped pnpm install (--no-install)");
+    }
+  } catch (error) {
+    // Roll back the partial scaffold so the command can simply be re-run
+    await rm(dir, { recursive: true, force: true });
+    if (webPackageJsonBackup !== null) {
+      await writeFile(webPackageJsonPath, webPackageJsonBackup);
+    }
+    console.error(`Failed — rolled back content/${slug} and apps/web/package.json.`);
+    throw error;
   }
 
   console.log(`

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -7,51 +7,20 @@
  *
  * Everything else (the content index, next.config.js transpilePackages, the
  * shadcn registry) discovers components from the content/ directory at runtime.
- *
- * Usage:
- *   pnpm new:content <slug> [--name "Display Name"] [--description "..."] [--no-install]
  */
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { defineCommand, runMain } from "citty";
+import consola from "consola";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const contentRoot = join(repoRoot, "content");
 const webPackageJsonPath = join(repoRoot, "apps", "web", "package.json");
 
-const usage = () => {
-  console.log(
-    'Usage: pnpm new:content <slug> [--name "Display Name"] [--description "..."] [--no-install]',
-  );
-  process.exit(1);
-};
-
-const parseArgs = (argv: string[]) => {
-  let slug: string | undefined;
-  let name: string | undefined;
-  let description: string | undefined;
-  let install = true;
-
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
-    if (arg === "--name") name = argv[++i];
-    else if (arg === "--description") description = argv[++i];
-    else if (arg === "--no-install") install = false;
-    else if (arg === "--help" || arg === "-h") usage();
-    else if (arg.startsWith("-")) {
-      console.error(`Unknown option: ${arg}`);
-      usage();
-    } else if (slug) {
-      console.error(`Unexpected argument: ${arg}`);
-      usage();
-    } else slug = arg;
-  }
-
-  if (!slug) usage();
-  return { slug: slug!, name, description, install };
-};
+const SLUG_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
 const toPascalCase = (slug: string) =>
   slug
@@ -128,7 +97,7 @@ const addWebDependency = async (slug: string): Promise<string | null> => {
   const dependencies = pkg.dependencies ?? {};
 
   if (dependencies[pkgName]) {
-    console.log(`- ${pkgName} already in apps/web/package.json, skipping`);
+    consola.info(`${pkgName} already in apps/web/package.json, skipping`);
     return null;
   }
 
@@ -145,66 +114,92 @@ const addWebDependency = async (slug: string): Promise<string | null> => {
 
   pkg.dependencies = next;
   await writeFile(webPackageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
-  console.log(`- Added ${pkgName} to apps/web/package.json`);
+  consola.info(`Added ${pkgName} to apps/web/package.json`);
   return raw;
 };
 
-const main = async () => {
-  const { slug, name, description, install } = parseArgs(process.argv.slice(2));
-
-  if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(slug)) {
-    console.error(`Invalid slug "${slug}". Use kebab-case, e.g. "my-component".`);
-    process.exit(1);
-  }
-
-  const dir = join(contentRoot, slug);
-  if (existsSync(dir)) {
-    console.error(`content/${slug} already exists.`);
-    process.exit(1);
-  }
-
-  const displayName = name ?? toTitleCase(slug);
-  const componentName = toPascalCase(slug);
-
-  let webPackageJsonBackup: string | null = null;
-  try {
-    await mkdir(dir, { recursive: true });
-    await Promise.all([
-      writeFile(join(dir, "meta.json"), metaJson(displayName, description ?? "")),
-      writeFile(join(dir, "package.json"), packageJson(slug)),
-      writeFile(join(dir, "preview.tsx"), previewTsx(slug, componentName)),
-      writeFile(join(dir, `${slug}.tsx`), componentTsx(componentName, displayName)),
-    ]);
-    console.log(`- Created content/${slug}`);
-
-    webPackageJsonBackup = await addWebDependency(slug);
-
-    if (install) {
-      console.log("- Running pnpm install...");
-      execSync("pnpm install", { cwd: repoRoot, stdio: "inherit" });
-    } else {
-      console.log("- Skipped pnpm install (--no-install)");
+const main = defineCommand({
+  meta: {
+    name: "new:content",
+    description: "Scaffold a new blank content component and register it in the web app.",
+  },
+  args: {
+    slug: {
+      type: "positional",
+      description: 'Lowercase, hyphenated slug — used as the directory name (e.g. "my-component").',
+      required: true,
+    },
+    name: {
+      type: "string",
+      description: "Display name shown in the UI. Defaults to the title-cased slug.",
+    },
+    description: {
+      type: "string",
+      description: "Short description for meta.json.",
+    },
+    install: {
+      type: "boolean",
+      description: "Run pnpm install to link the workspace package (--no-install to skip).",
+      default: true,
+    },
+  },
+  run: async ({ args }) => {
+    const slug = args.slug.trim().toLowerCase();
+    if (!SLUG_RE.test(slug)) {
+      consola.error(`Invalid slug "${args.slug}". Use kebab-case, e.g. "my-component".`);
+      process.exit(1);
     }
-  } catch (error) {
-    // Roll back the partial scaffold so the command can simply be re-run
-    await rm(dir, { recursive: true, force: true });
-    if (webPackageJsonBackup !== null) {
-      await writeFile(webPackageJsonPath, webPackageJsonBackup);
+
+    const dir = join(contentRoot, slug);
+    if (existsSync(dir)) {
+      consola.error(`content/${slug} already exists.`);
+      process.exit(1);
     }
-    console.error(`Failed — rolled back content/${slug} and apps/web/package.json.`);
-    throw error;
-  }
 
-  console.log(`
-Done! Next steps:
-  1. Build your component in content/${slug}/${slug}.tsx
-  2. Stage it in content/${slug}/preview.tsx
-  3. Fill in description/tags (and optional coverUrl) in content/${slug}/meta.json
-  4. View it at http://localhost:3000/ui/${slug} (pnpm dev:web)
-`);
-};
+    const displayName = args.name ?? toTitleCase(slug);
+    const componentName = toPascalCase(slug);
 
-main().catch((error: unknown) => {
-  console.error(error);
-  process.exit(1);
+    consola.start(`Scaffolding content/${slug}`);
+
+    let webPackageJsonBackup: string | null = null;
+    try {
+      await mkdir(dir, { recursive: true });
+      await Promise.all([
+        writeFile(join(dir, "meta.json"), metaJson(displayName, args.description ?? "")),
+        writeFile(join(dir, "package.json"), packageJson(slug)),
+        writeFile(join(dir, "preview.tsx"), previewTsx(slug, componentName)),
+        writeFile(join(dir, `${slug}.tsx`), componentTsx(componentName, displayName)),
+      ]);
+      consola.info(`Created content/${slug}`);
+
+      webPackageJsonBackup = await addWebDependency(slug);
+
+      if (args.install) {
+        consola.info("Running pnpm install...");
+        execSync("pnpm install", { cwd: repoRoot, stdio: "inherit" });
+      } else {
+        consola.info("Skipped pnpm install (--no-install)");
+      }
+    } catch (error) {
+      // Roll back the partial scaffold so the command can simply be re-run
+      await rm(dir, { recursive: true, force: true });
+      if (webPackageJsonBackup !== null) {
+        await writeFile(webPackageJsonPath, webPackageJsonBackup);
+      }
+      consola.error(`Failed — rolled back content/${slug} and apps/web/package.json.`);
+      throw error;
+    }
+
+    consola.success(`Scaffolded content/${slug}`);
+    consola.log("");
+    consola.info("Next steps:");
+    consola.log(`  1. Build your component in content/${slug}/${slug}.tsx`);
+    consola.log(`  2. Stage it in content/${slug}/preview.tsx`);
+    consola.log(
+      `  3. Fill in description/tags (and optional coverUrl) in content/${slug}/meta.json`,
+    );
+    consola.log(`  4. View it at http://localhost:3000/ui/${slug} (pnpm dev:web)`);
+  },
 });
+
+void runMain(main);

--- a/scripts/new-content.ts
+++ b/scripts/new-content.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env tsx
+/**
+ * Scaffolds a new content component:
+ *   1. Creates content/<slug>/ with meta.json, package.json, preview.tsx, <slug>.tsx
+ *   2. Adds @uicapsule/<slug> to apps/web/package.json dependencies
+ *   3. Runs pnpm install to link the workspace package
+ *
+ * Everything else (the content index, next.config.js transpilePackages, the
+ * shadcn registry) discovers components from the content/ directory at runtime.
+ *
+ * Usage:
+ *   pnpm new:content <slug> [--name "Display Name"] [--description "..."] [--no-install]
+ */
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const contentRoot = join(repoRoot, "content");
+const webPackageJsonPath = join(repoRoot, "apps", "web", "package.json");
+
+const usage = () => {
+  console.log(
+    'Usage: pnpm new:content <slug> [--name "Display Name"] [--description "..."] [--no-install]',
+  );
+  process.exit(1);
+};
+
+const parseArgs = (argv: string[]) => {
+  let slug: string | undefined;
+  let name: string | undefined;
+  let description: string | undefined;
+  let install = true;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--name") name = argv[++i];
+    else if (arg === "--description") description = argv[++i];
+    else if (arg === "--no-install") install = false;
+    else if (arg === "--help" || arg === "-h") usage();
+    else if (arg.startsWith("-")) {
+      console.error(`Unknown option: ${arg}`);
+      usage();
+    } else if (slug) {
+      console.error(`Unexpected argument: ${arg}`);
+      usage();
+    } else slug = arg;
+  }
+
+  if (!slug) usage();
+  return { slug: slug!, name, description, install };
+};
+
+const toPascalCase = (slug: string) =>
+  slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+
+const toTitleCase = (slug: string) =>
+  slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+
+const metaJson = (name: string, description: string) =>
+  JSON.stringify({ name, description, tags: [] }, null, 2) + "\n";
+
+const packageJson = (slug: string) =>
+  JSON.stringify(
+    {
+      name: `@uicapsule/${slug}`,
+      version: "0.1.0",
+      private: true,
+      type: "module",
+      scripts: {
+        clean: "git clean -xdf .cache .turbo dist node_modules",
+      },
+      dependencies: {
+        react: "catalog:",
+        "react-dom": "catalog:",
+      },
+      exports: {
+        "./preview": "./preview.tsx",
+      },
+      devDependencies: {
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+      },
+    },
+    null,
+    2,
+  ) + "\n";
+
+const previewTsx = (slug: string, componentName: string) => `"use client";
+
+import { ${componentName} } from "./${slug}";
+
+const Preview = () => {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <${componentName} />
+    </div>
+  );
+};
+
+export default Preview;
+`;
+
+const componentTsx = (componentName: string, displayName: string) => `"use client";
+
+export const ${componentName} = () => {
+  return <div>${displayName}</div>;
+};
+`;
+
+/**
+ * Inserts the dependency in alphabetical position without re-sorting existing
+ * keys, so unrelated lines never change.
+ */
+const addWebDependency = async (slug: string) => {
+  const pkgName = `@uicapsule/${slug}`;
+  const raw = await readFile(webPackageJsonPath, "utf-8");
+  const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+  const dependencies = pkg.dependencies ?? {};
+
+  if (dependencies[pkgName]) {
+    console.log(`- ${pkgName} already in apps/web/package.json, skipping`);
+    return;
+  }
+
+  const next: Record<string, string> = {};
+  let inserted = false;
+  for (const [key, value] of Object.entries(dependencies)) {
+    if (!inserted && pkgName.localeCompare(key) < 0) {
+      next[pkgName] = "workspace:*";
+      inserted = true;
+    }
+    next[key] = value;
+  }
+  if (!inserted) next[pkgName] = "workspace:*";
+
+  pkg.dependencies = next;
+  await writeFile(webPackageJsonPath, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`- Added ${pkgName} to apps/web/package.json`);
+};
+
+const main = async () => {
+  const { slug, name, description, install } = parseArgs(process.argv.slice(2));
+
+  if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(slug)) {
+    console.error(`Invalid slug "${slug}". Use kebab-case, e.g. "my-component".`);
+    process.exit(1);
+  }
+
+  const dir = join(contentRoot, slug);
+  if (existsSync(dir)) {
+    console.error(`content/${slug} already exists.`);
+    process.exit(1);
+  }
+
+  const displayName = name ?? toTitleCase(slug);
+  const componentName = toPascalCase(slug);
+
+  await mkdir(dir, { recursive: true });
+  await Promise.all([
+    writeFile(join(dir, "meta.json"), metaJson(displayName, description ?? "")),
+    writeFile(join(dir, "package.json"), packageJson(slug)),
+    writeFile(join(dir, "preview.tsx"), previewTsx(slug, componentName)),
+    writeFile(join(dir, `${slug}.tsx`), componentTsx(componentName, displayName)),
+  ]);
+  console.log(`- Created content/${slug}`);
+
+  await addWebDependency(slug);
+
+  if (install) {
+    console.log("- Running pnpm install...");
+    execSync("pnpm install", { cwd: repoRoot, stdio: "inherit" });
+  } else {
+    console.log("- Skipped pnpm install (--no-install)");
+  }
+
+  console.log(`
+Done! Next steps:
+  1. Build your component in content/${slug}/${slug}.tsx
+  2. Stage it in content/${slug}/preview.tsx
+  3. Fill in description/tags (and optional coverUrl) in content/${slug}/meta.json
+  4. View it at http://localhost:3000/ui/${slug} (pnpm dev:web)
+`);
+};
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a CLI command that scaffolds a new blank content component and wires it up everywhere it needs to be registered. Built with [citty](https://github.com/unjs/citty) + [consola](https://github.com/unjs/consola) — the same CLI stack as the vibedgames CLI — so it gets proper `--help`, arg parsing, and `--no-install` negation for free.

```bash
pnpm new:content my-component
pnpm new:content my-component --name "My Component" --description "..." --no-install
pnpm new:content --help
```

What it does:

1. Creates `content/<slug>/` with `meta.json`, `package.json`, `preview.tsx`, and `<slug>.tsx`, modeled on the existing components (e.g. `like-button`)
2. Inserts `"@uicapsule/<slug>": "workspace:*"` into `apps/web/package.json` dependencies in alphabetical position (without re-sorting existing keys, so the diff is one line)
3. Runs `pnpm install` to link the workspace package (skippable with `--no-install`)

Everything else is already dynamic — the content index (`packages/api/src/content/content-fs.ts`), `next.config.js` `transpilePackages`, the preview-frame route, and the shadcn registry all discover components from the `content/` directory at runtime — so no other registration is needed.

The command validates kebab-case slugs, refuses to overwrite an existing component, escapes the display name when emitting JSX, rolls back the scaffold (directory + package.json edit) if a later step fails so it can simply be re-run, and prints next steps. Also documented in CLAUDE.md's Common Commands.

## Test plan

- [x] Ran `pnpm new:content test-widget` end to end: files generated, dependency inserted in correct alphabetical position with a one-line diff, `pnpm install` linked the package (test component removed afterwards)
- [x] Hostile `--name 'Weird <Name> {with} `chars`'` produces valid TSX
- [x] Forced `pnpm install` failure rolls back `content/<slug>` and `apps/web/package.json`
- [x] Duplicate slug and invalid slug are rejected with exit code 1
- [x] `pnpm typecheck` passes (6/6 tasks)
- [x] `oxlint` / `oxfmt --check` clean

https://claude.ai/code/session_013T3po2LUDd3HVeiF9JyG4j

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only scaffolding and docs; no production runtime or auth/data paths change.
> 
> **Overview**
> Adds **`pnpm new:content <slug>`** so developers can scaffold a new UI content package without hand-copying an existing component.
> 
> The new **`scripts/new-content.ts`** CLI (citty + consola) validates kebab-case slugs, refuses overwrites, and creates **`content/<slug>/`** with **`meta.json`**, workspace **`package.json`**, **`preview.tsx`**, and a stub **`<slug>.tsx`**. It inserts **`@uicapsule/<slug>`** into **`apps/web/package.json`** in alphabetical order without re-sorting other deps, runs **`pnpm install`** by default (skippable with **`--no-install`**), and rolls back the folder plus web **`package.json`** on failure. Optional **`--name`** and **`--description`** flags customize metadata.
> 
> Root **`package.json`** wires the script; **`CLAUDE.md`** documents it. No runtime app changes—discovery stays filesystem-based.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17423b2caaf341ca83f7c0b9ba4fe427d525f5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->