### PR TITLE
feat(spinner-pixel-grid): add 12 new dot-matrix loader variants

### DIFF
--- a/content/spinner-pixel-grid/preview.tsx
+++ b/content/spinner-pixel-grid/preview.tsx
@@ -11,6 +11,7 @@ import {
 
 const Preview = () => {
   const [glow, setGlow] = useState(true);
+  const [rainbow, setRainbow] = useState(true);
   const [shape, setShape] = useState<SpinnerShape>("square");
 
   return (
@@ -19,6 +20,10 @@ const Preview = () => {
         <label className="flex items-center gap-2 text-sm text-gray-300">
           <input type="checkbox" checked={glow} onChange={(e) => setGlow(e.target.checked)} />
           Glow
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-300">
+          <input type="checkbox" checked={rainbow} onChange={(e) => setRainbow(e.target.checked)} />
+          Rainbow
         </label>
         <div className="flex items-center gap-2 text-sm text-gray-300">
           Shape:
@@ -50,9 +55,9 @@ const Preview = () => {
               variant={variant}
               shape={shape}
               glow={glow}
+              rainbow={rainbow}
               size={10}
               gridSize={5}
-              rainbow
             />
             <span className="text-xs text-gray-500">{variant}</span>
           </div>

--- a/content/spinner-pixel-grid/preview.tsx
+++ b/content/spinner-pixel-grid/preview.tsx
@@ -4,13 +4,13 @@ import { SpinnerPixelGrid, spinnerVariants } from "./spinner-pixel-grid";
 
 const Preview = () => {
   return (
-    <div className="grid min-h-screen grid-cols-2 bg-black pb-32 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+    <div className="grid min-h-screen grid-cols-2 bg-black text-yellow-300 pb-32 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
       {spinnerVariants.map((variant) => (
         <div
           key={variant}
           className="flex flex-col items-center justify-center gap-4 border border-white/10 p-8"
         >
-          <SpinnerPixelGrid variant={variant} size={10} gridSize={5} />
+          <SpinnerPixelGrid variant={variant} size={10} gridSize={5} rainbow />
           <span className="text-xs text-gray-500">{variant}</span>
         </div>
       ))}

--- a/content/spinner-pixel-grid/preview.tsx
+++ b/content/spinner-pixel-grid/preview.tsx
@@ -26,6 +26,7 @@ const Preview = () => {
             <button
               key={s}
               type="button"
+              aria-pressed={shape === s}
               onClick={() => setShape(s)}
               className={
                 shape === s

--- a/content/spinner-pixel-grid/preview.tsx
+++ b/content/spinner-pixel-grid/preview.tsx
@@ -2,24 +2,18 @@
 
 import { SpinnerPixelGrid, spinnerVariants } from "./spinner-pixel-grid";
 
-const sizes = [6, 10, 14];
-
 const Preview = () => {
   return (
-    <div className="grid min-h-screen grid-cols-3 bg-black pb-32">
-      {spinnerVariants.map((variant) =>
-        sizes.map((size) => (
-          <div
-            key={`${variant}-${size}`}
-            className="flex flex-col items-center justify-center gap-3 border border-white/10 p-6"
-          >
-            <SpinnerPixelGrid variant={variant} size={size} gridSize={5} />
-            <span className="text-xs text-gray-500">
-              {variant} ({size}px)
-            </span>
-          </div>
-        )),
-      )}
+    <div className="grid min-h-screen grid-cols-2 bg-black pb-32 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+      {spinnerVariants.map((variant) => (
+        <div
+          key={variant}
+          className="flex flex-col items-center justify-center gap-4 border border-white/10 p-8"
+        >
+          <SpinnerPixelGrid variant={variant} size={10} gridSize={5} />
+          <span className="text-xs text-gray-500">{variant}</span>
+        </div>
+      ))}
     </div>
   );
 };

--- a/content/spinner-pixel-grid/preview.tsx
+++ b/content/spinner-pixel-grid/preview.tsx
@@ -1,19 +1,62 @@
 "use client";
 
-import { SpinnerPixelGrid, spinnerVariants } from "./spinner-pixel-grid";
+import { useState } from "react";
+
+import {
+  SpinnerPixelGrid,
+  spinnerShapes,
+  spinnerVariants,
+  type SpinnerShape,
+} from "./spinner-pixel-grid";
 
 const Preview = () => {
+  const [glow, setGlow] = useState(true);
+  const [shape, setShape] = useState<SpinnerShape>("square");
+
   return (
-    <div className="grid min-h-screen grid-cols-2 bg-black text-yellow-300 pb-32 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-      {spinnerVariants.map((variant) => (
-        <div
-          key={variant}
-          className="flex flex-col items-center justify-center gap-4 border border-white/10 p-8"
-        >
-          <SpinnerPixelGrid variant={variant} size={10} gridSize={5} rainbow />
-          <span className="text-xs text-gray-500">{variant}</span>
+    <div className="min-h-screen bg-black text-yellow-300">
+      <div className="sticky top-0 z-10 flex flex-wrap items-center gap-4 border-b border-white/10 bg-black/80 p-4 backdrop-blur">
+        <label className="flex items-center gap-2 text-sm text-gray-300">
+          <input type="checkbox" checked={glow} onChange={(e) => setGlow(e.target.checked)} />
+          Glow
+        </label>
+        <div className="flex items-center gap-2 text-sm text-gray-300">
+          Shape:
+          {spinnerShapes.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => setShape(s)}
+              className={
+                shape === s
+                  ? "rounded bg-white/15 px-2 py-1 capitalize"
+                  : "rounded px-2 py-1 capitalize text-gray-500 hover:text-gray-300"
+              }
+            >
+              {s}
+            </button>
+          ))}
         </div>
-      ))}
+      </div>
+
+      <div className="grid grid-cols-2 pb-32 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+        {spinnerVariants.map((variant) => (
+          <div
+            key={variant}
+            className="flex flex-col items-center justify-center gap-4 border border-white/10 p-8"
+          >
+            <SpinnerPixelGrid
+              variant={variant}
+              shape={shape}
+              glow={glow}
+              size={10}
+              gridSize={5}
+              rainbow
+            />
+            <span className="text-xs text-gray-500">{variant}</span>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/content/spinner-pixel-grid/spinner-pixel-grid.css
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.css
@@ -46,6 +46,30 @@
   }
 }
 
+@keyframes pixel-beat {
+  0%,
+  100% {
+    opacity: 0.3;
+    transform: scale(0.7);
+  }
+  15% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  30% {
+    opacity: 0.5;
+    transform: scale(0.85);
+  }
+  45% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  60% {
+    opacity: 0.3;
+    transform: scale(0.7);
+  }
+}
+
 @keyframes hue-rotate {
   from {
     filter: hue-rotate(0deg);

--- a/content/spinner-pixel-grid/spinner-pixel-grid.tsx
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.tsx
@@ -8,12 +8,24 @@ import "./spinner-pixel-grid.css";
 const variants = [
   "default",
   "wave",
+  "cascade",
   "spiral",
+  "vortex",
   "chase",
+  "frame",
   "rain",
+  "scan",
+  "ripple",
+  "diamond",
   "star",
+  "saltire",
   "crosshair",
+  "corners",
+  "checker",
   "snake",
+  "radar",
+  "pulse",
+  "heart",
 ] as const;
 
 type SpinnerVariant = (typeof variants)[number];
@@ -22,6 +34,14 @@ type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
   size?: number;
   gridSize?: number;
   variant?: SpinnerVariant;
+};
+
+// Heart shape mask via the implicit heart curve, normalized to the grid.
+const isHeartPixel = (x: number, y: number, gridSize: number): boolean => {
+  const center = (gridSize - 1) / 2;
+  const nx = (x - center) / (gridSize * 0.48);
+  const ny = (center - y) / (gridSize * 0.34) + 0.05;
+  return Math.pow(nx * nx + ny * ny - 1, 3) - nx * nx * Math.pow(ny, 3) <= 0;
 };
 
 // Get animation delay based on variant and position
@@ -42,6 +62,10 @@ const getAnimationDelay = (
       // Horizontal wave
       return `${0.1 * x}s`;
 
+    case "cascade":
+      // Vertical wave, top to bottom
+      return `${0.12 * y}s`;
+
     case "spiral": {
       // Spiral from center outward
       const dx = x - center;
@@ -50,6 +74,16 @@ const getAnimationDelay = (
       const angle = Math.atan2(dy, dx);
       const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
       return `${(distance * 0.15 + normalizedAngle * 0.3).toFixed(2)}s`;
+    }
+
+    case "vortex": {
+      // Rotating arm that also pulses radially
+      const dx = x - center;
+      const dy = y - center;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      const angle = Math.atan2(dy, dx);
+      const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
+      return `${(normalizedAngle * 1.2 + distance * 0.1).toFixed(2)}s`;
     }
 
     case "chase": {
@@ -72,9 +106,31 @@ const getAnimationDelay = (
       return `${(order / perimeter) * 0.8}s`;
     }
 
+    case "frame":
+      // Whole border pulses together
+      return "0s";
+
     case "rain":
       // Rain falling from top, each column offset
       return `${y * 0.1 + x * 0.05}s`;
+
+    case "scan":
+      // Sharp scanline sweeping downward
+      return `${y * 0.15}s`;
+
+    case "ripple": {
+      // Concentric rings radiating from the center
+      const dx = x - center;
+      const dy = y - center;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+      return `${(distance * 0.18).toFixed(2)}s`;
+    }
+
+    case "diamond": {
+      // Diamond-shaped rings (manhattan distance) from the center
+      const manhattan = Math.abs(x - center) + Math.abs(y - center);
+      return `${(manhattan * 0.12).toFixed(2)}s`;
+    }
 
     case "star": {
       // Star pattern - radiates outward from center along cross and diagonals
@@ -89,6 +145,13 @@ const getAnimationDelay = (
       return `${dist * 0.12}s`;
     }
 
+    case "saltire": {
+      // Diagonal cross (X) radiating from the center
+      const centerIdx = Math.floor(gridSize / 2);
+      const dist = Math.max(Math.abs(x - centerIdx), Math.abs(y - centerIdx));
+      return `${dist * 0.12}s`;
+    }
+
     case "crosshair": {
       // Center row and column animate outward from center
       const centerIdx = Math.floor(gridSize / 2);
@@ -100,11 +163,47 @@ const getAnimationDelay = (
       return `${distFromCenter * 0.1}s`;
     }
 
+    case "corners": {
+      // Collapse inward from all four corners
+      const last = gridSize - 1;
+      const cornerPoints: [number, number][] = [
+        [0, 0],
+        [last, 0],
+        [0, last],
+        [last, last],
+      ];
+      let nearest = Infinity;
+      for (const [cx, cy] of cornerPoints) {
+        const d = Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
+        if (d < nearest) nearest = d;
+      }
+      return `${(nearest * 0.15).toFixed(2)}s`;
+    }
+
+    case "checker":
+      // Alternating checkerboard pulse
+      return `${((x + y) % 2) * 0.5}s`;
+
     case "snake": {
       // Snake pattern (alternating direction per row)
       const effectiveX = y % 2 === 0 ? x : gridSize - 1 - x;
       return `${(y * gridSize + effectiveX) * 0.05}s`;
     }
+
+    case "radar": {
+      // Radar sweep around the center
+      const angle = Math.atan2(y - center, x - center);
+      const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
+      return `${(normalizedAngle * 1.2).toFixed(2)}s`;
+    }
+
+    case "pulse":
+      // Every dot breathes together
+      return "0s";
+
+    case "heart":
+      // Whole heart beats together
+      return "0s";
 
     default:
       return `${0.05 * (x + y)}s`;
@@ -115,11 +214,17 @@ const getAnimationDelay = (
 const getAnimationName = (variant: SpinnerVariant): string => {
   switch (variant) {
     case "chase":
+    case "frame":
+    case "scan":
+    case "radar":
+    case "vortex":
       return "pixel-chase";
     case "rain":
       return "pixel-rain";
     case "crosshair":
       return "pixel-crosshair";
+    case "heart":
+      return "pixel-beat";
     default:
       return "pixel-scale";
   }
@@ -129,13 +234,18 @@ const getAnimationName = (variant: SpinnerVariant): string => {
 const getAnimationDuration = (variant: SpinnerVariant): string => {
   switch (variant) {
     case "chase":
-      return "0.8s";
     case "rain":
       return "0.8s";
     case "crosshair":
       return "0.6s";
     case "snake":
       return "1.5s";
+    case "scan":
+    case "radar":
+    case "vortex":
+      return "1.2s";
+    case "heart":
+      return "1.2s";
     default:
       return "1s";
   }
@@ -148,7 +258,7 @@ const shouldShowPixel = (
   y: number,
   gridSize: number,
 ): boolean => {
-  if (variant === "chase") {
+  if (variant === "chase" || variant === "frame") {
     const isTop = y === 0;
     const isBottom = y === gridSize - 1;
     const isLeft = x === 0;
@@ -166,9 +276,18 @@ const shouldShowPixel = (
     return (isCross || isDiagonal) && !isCorner;
   }
 
+  if (variant === "saltire") {
+    const centerIdx = Math.floor(gridSize / 2);
+    return Math.abs(x - centerIdx) === Math.abs(y - centerIdx);
+  }
+
   if (variant === "crosshair") {
     const centerIdx = Math.floor(gridSize / 2);
     return x === centerIdx || y === centerIdx;
+  }
+
+  if (variant === "heart") {
+    return isHeartPixel(x, y, gridSize);
   }
 
   return true;

--- a/content/spinner-pixel-grid/spinner-pixel-grid.tsx
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { forwardRef, type CSSProperties, type HTMLAttributes } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+} from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 import "./spinner-pixel-grid.css";
@@ -31,9 +37,34 @@ const variants = [
 type SpinnerVariant = (typeof variants)[number];
 
 type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
+  /** Pixel size of each dot. */
   size?: number;
+  /** Number of dots per row/column. */
   gridSize?: number;
   variant?: SpinnerVariant;
+  /** Dot color. Any CSS color; defaults to the inherited text color. */
+  color?: string;
+  /** Animation speed multiplier. 2 = twice as fast, 0.5 = half speed. */
+  speed?: number;
+  /** Cycle the hue of every dot for a rainbow effect. */
+  rainbow?: boolean;
+  /** Accessible label announced by screen readers. */
+  ariaLabel?: string;
+};
+
+// Respect the user's reduced-motion preference.
+const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setPrefersReducedMotion(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return prefersReducedMotion;
 };
 
 // Heart shape mask via the implicit heart curve, normalized to the grid.
@@ -44,27 +75,27 @@ const isHeartPixel = (x: number, y: number, gridSize: number): boolean => {
   return Math.pow(nx * nx + ny * ny - 1, 3) - nx * nx * Math.pow(ny, 3) <= 0;
 };
 
-// Get animation delay based on variant and position
+// Get animation delay (in seconds) based on variant and position
 const getAnimationDelay = (
   variant: SpinnerVariant,
   x: number,
   y: number,
   gridSize: number,
-): string => {
+): number => {
   const center = (gridSize - 1) / 2;
 
   switch (variant) {
     case "default":
       // Diagonal wave from top-left
-      return `${0.05 * (x + y)}s`;
+      return 0.05 * (x + y);
 
     case "wave":
       // Horizontal wave
-      return `${0.1 * x}s`;
+      return 0.1 * x;
 
     case "cascade":
       // Vertical wave, top to bottom
-      return `${0.12 * y}s`;
+      return 0.12 * y;
 
     case "spiral": {
       // Spiral from center outward
@@ -73,7 +104,7 @@ const getAnimationDelay = (
       const distance = Math.sqrt(dx * dx + dy * dy);
       const angle = Math.atan2(dy, dx);
       const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return `${(distance * 0.15 + normalizedAngle * 0.3).toFixed(2)}s`;
+      return distance * 0.15 + normalizedAngle * 0.3;
     }
 
     case "vortex": {
@@ -83,7 +114,7 @@ const getAnimationDelay = (
       const distance = Math.sqrt(dx * dx + dy * dy);
       const angle = Math.atan2(dy, dx);
       const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return `${(normalizedAngle * 1.2 + distance * 0.1).toFixed(2)}s`;
+      return normalizedAngle * 1.2 + distance * 0.1;
     }
 
     case "chase": {
@@ -94,7 +125,7 @@ const getAnimationDelay = (
       const isRight = x === gridSize - 1;
       const isEdge = isTop || isBottom || isLeft || isRight;
 
-      if (!isEdge) return "0s";
+      if (!isEdge) return 0;
 
       let order = 0;
       if (isTop) order = x;
@@ -103,33 +134,33 @@ const getAnimationDelay = (
       else if (isLeft) order = 3 * (gridSize - 1) + (gridSize - 1 - y);
 
       const perimeter = 4 * (gridSize - 1);
-      return `${(order / perimeter) * 0.8}s`;
+      return (order / perimeter) * 0.8;
     }
 
     case "frame":
       // Whole border pulses together
-      return "0s";
+      return 0;
 
     case "rain":
       // Rain falling from top, each column offset
-      return `${y * 0.1 + x * 0.05}s`;
+      return y * 0.1 + x * 0.05;
 
     case "scan":
       // Sharp scanline sweeping downward
-      return `${y * 0.15}s`;
+      return y * 0.15;
 
     case "ripple": {
       // Concentric rings radiating from the center
       const dx = x - center;
       const dy = y - center;
       const distance = Math.sqrt(dx * dx + dy * dy);
-      return `${(distance * 0.18).toFixed(2)}s`;
+      return distance * 0.18;
     }
 
     case "diamond": {
       // Diamond-shaped rings (manhattan distance) from the center
       const manhattan = Math.abs(x - center) + Math.abs(y - center);
-      return `${(manhattan * 0.12).toFixed(2)}s`;
+      return manhattan * 0.12;
     }
 
     case "star": {
@@ -139,17 +170,17 @@ const getAnimationDelay = (
       const dy = y - centerIdx;
       const isCross = x === centerIdx || y === centerIdx;
       const isDiagonal = Math.abs(dx) === Math.abs(dy);
-      if (!isCross && !isDiagonal) return "0s";
+      if (!isCross && !isDiagonal) return 0;
 
       const dist = Math.max(Math.abs(dx), Math.abs(dy));
-      return `${dist * 0.12}s`;
+      return dist * 0.12;
     }
 
     case "saltire": {
       // Diagonal cross (X) radiating from the center
       const centerIdx = Math.floor(gridSize / 2);
       const dist = Math.max(Math.abs(x - centerIdx), Math.abs(y - centerIdx));
-      return `${dist * 0.12}s`;
+      return dist * 0.12;
     }
 
     case "crosshair": {
@@ -157,10 +188,12 @@ const getAnimationDelay = (
       const centerIdx = Math.floor(gridSize / 2);
       const isCenterRow = y === centerIdx;
       const isCenterCol = x === centerIdx;
-      if (!isCenterRow && !isCenterCol) return "0s";
+      if (!isCenterRow && !isCenterCol) return 0;
 
-      const distFromCenter = isCenterRow ? Math.abs(x - centerIdx) : Math.abs(y - centerIdx);
-      return `${distFromCenter * 0.1}s`;
+      const distFromCenter = isCenterRow
+        ? Math.abs(x - centerIdx)
+        : Math.abs(y - centerIdx);
+      return distFromCenter * 0.1;
     }
 
     case "corners": {
@@ -177,36 +210,36 @@ const getAnimationDelay = (
         const d = Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
         if (d < nearest) nearest = d;
       }
-      return `${(nearest * 0.15).toFixed(2)}s`;
+      return nearest * 0.15;
     }
 
     case "checker":
       // Alternating checkerboard pulse
-      return `${((x + y) % 2) * 0.5}s`;
+      return ((x + y) % 2) * 0.5;
 
     case "snake": {
       // Snake pattern (alternating direction per row)
       const effectiveX = y % 2 === 0 ? x : gridSize - 1 - x;
-      return `${(y * gridSize + effectiveX) * 0.05}s`;
+      return (y * gridSize + effectiveX) * 0.05;
     }
 
     case "radar": {
       // Radar sweep around the center
       const angle = Math.atan2(y - center, x - center);
       const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return `${(normalizedAngle * 1.2).toFixed(2)}s`;
+      return normalizedAngle * 1.2;
     }
 
     case "pulse":
       // Every dot breathes together
-      return "0s";
+      return 0;
 
     case "heart":
       // Whole heart beats together
-      return "0s";
+      return 0;
 
     default:
-      return `${0.05 * (x + y)}s`;
+      return 0.05 * (x + y);
   }
 };
 
@@ -230,24 +263,24 @@ const getAnimationName = (variant: SpinnerVariant): string => {
   }
 };
 
-// Get animation duration for variant
-const getAnimationDuration = (variant: SpinnerVariant): string => {
+// Get animation duration (in seconds) for variant
+const getAnimationDuration = (variant: SpinnerVariant): number => {
   switch (variant) {
     case "chase":
     case "rain":
-      return "0.8s";
+      return 0.8;
     case "crosshair":
-      return "0.6s";
+      return 0.6;
     case "snake":
-      return "1.5s";
+      return 1.5;
     case "scan":
     case "radar":
     case "vortex":
-      return "1.2s";
+      return 1.2;
     case "heart":
-      return "1.2s";
+      return 1.2;
     default:
-      return "1s";
+      return 1;
   }
 };
 
@@ -272,7 +305,8 @@ const shouldShowPixel = (
     const dy = y - centerIdx;
     const isCross = x === centerIdx || y === centerIdx;
     const isDiagonal = Math.abs(dx) === Math.abs(dy);
-    const isCorner = (x === 0 || x === gridSize - 1) && (y === 0 || y === gridSize - 1);
+    const isCorner =
+      (x === 0 || x === gridSize - 1) && (y === 0 || y === gridSize - 1);
     return (isCross || isDiagonal) && !isCorner;
   }
 
@@ -294,38 +328,73 @@ const shouldShowPixel = (
 };
 
 export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
-  ({ className, size = 8, gridSize = 3, variant = "default", ...props }, ref) => {
+  (
+    {
+      className,
+      size = 8,
+      gridSize = 3,
+      variant = "default",
+      color = "currentColor",
+      speed = 1,
+      rainbow = false,
+      ariaLabel = "Loading",
+      ...props
+    },
+    ref,
+  ) => {
+    const prefersReducedMotion = usePrefersReducedMotion();
+    const animate = !prefersReducedMotion;
+    const safeSpeed = speed > 0 ? speed : 1;
+
     const squareSize = `${size}px`;
     const gridArray = Array.from({ length: gridSize }, (_, i) => i);
+
+    const animationName = getAnimationName(variant);
+    const duration = getAnimationDuration(variant) / safeSpeed;
+    const hueRotate = `hue-rotate ${10 / safeSpeed}s linear infinite`;
 
     return (
       <div
         ref={ref}
+        role="status"
+        aria-label={ariaLabel}
         className={cn("inline-flex flex-col gap-0", className)}
-        style={{ "--square-size": squareSize } as CSSProperties}
+        style={
+          {
+            "--square-size": squareSize,
+            "--spinner-color": color,
+          } as CSSProperties
+        }
         {...props}
       >
         {gridArray.map((y) => (
           <div key={y} className="flex gap-0">
             {gridArray.map((x) => {
               const show = shouldShowPixel(variant, x, y, gridSize);
+              const delay = getAnimationDelay(variant, x, y, gridSize) / safeSpeed;
               return (
                 <div
                   key={x}
-                  className="relative inline-block animate-[hue-rotate_10s_linear_infinite]"
+                  className="relative inline-block"
                   style={{
                     width: "var(--square-size)",
                     height: "var(--square-size)",
+                    animation: rainbow && animate ? hueRotate : undefined,
                   }}
                 >
                   {show && (
                     <div
-                      className="absolute top-0 left-0 bg-[#ff0] [box-shadow:0_0_10px_#ff0,0_0_20px_#ff0,0_0_40px_#ff0]"
+                      className="absolute top-0 left-0"
                       style={{
                         width: "var(--square-size)",
                         height: "var(--square-size)",
-                        animation: `${getAnimationName(variant)} ${getAnimationDuration(variant)} linear infinite`,
-                        animationDelay: getAnimationDelay(variant, x, y, gridSize),
+                        backgroundColor: "var(--spinner-color)",
+                        boxShadow:
+                          "0 0 10px var(--spinner-color), 0 0 20px var(--spinner-color), 0 0 40px var(--spinner-color)",
+                        animation: animate
+                          ? `${animationName} ${duration}s linear infinite`
+                          : undefined,
+                        animationDelay: animate ? `${delay}s` : undefined,
                       }}
                     />
                   )}

--- a/content/spinner-pixel-grid/spinner-pixel-grid.tsx
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.tsx
@@ -1,40 +1,194 @@
 "use client";
 
-import {
-  forwardRef,
-  useEffect,
-  useState,
-  type CSSProperties,
-  type HTMLAttributes,
-} from "react";
+import { forwardRef, useEffect, useState, type CSSProperties, type HTMLAttributes } from "react";
 import { cn } from "@repo/ui/lib/utils";
 
 import "./spinner-pixel-grid.css";
 
-const variants = [
-  "default",
-  "wave",
-  "cascade",
-  "spiral",
-  "vortex",
-  "chase",
-  "frame",
-  "rain",
-  "scan",
-  "ripple",
-  "diamond",
-  "star",
-  "saltire",
-  "crosshair",
-  "corners",
-  "checker",
-  "snake",
-  "radar",
-  "pulse",
-  "heart",
-] as const;
+type CellValue = (x: number, y: number, gridSize: number) => number;
+type CellMask = (x: number, y: number, gridSize: number) => boolean;
 
-type SpinnerVariant = (typeof variants)[number];
+interface VariantConfig {
+  /** Keyframe animation applied to each visible dot. */
+  keyframe: string;
+  /** Base animation duration in seconds. */
+  duration: number;
+  /** Animation delay (seconds) for the dot at (x, y). */
+  delay: CellValue;
+  /** Which dots are part of the pattern. Defaults to all. */
+  mask?: CellMask;
+}
+
+// --- Shape masks (which dots make up a variant's pattern) ---
+
+const edgeMask: CellMask = (x, y, g) => x === 0 || y === 0 || x === g - 1 || y === g - 1;
+
+const starMask: CellMask = (x, y, g) => {
+  const c = Math.floor(g / 2);
+  const isCross = x === c || y === c;
+  const isDiagonal = Math.abs(x - c) === Math.abs(y - c);
+  const isCorner = (x === 0 || x === g - 1) && (y === 0 || y === g - 1);
+  return (isCross || isDiagonal) && !isCorner;
+};
+
+const saltireMask: CellMask = (x, y, g) => {
+  const c = Math.floor(g / 2);
+  return Math.abs(x - c) === Math.abs(y - c);
+};
+
+const crosshairMask: CellMask = (x, y, g) => {
+  const c = Math.floor(g / 2);
+  return x === c || y === c;
+};
+
+// Heart shape via the implicit heart curve, normalized to the grid.
+const heartMask: CellMask = (x, y, g) => {
+  const c = (g - 1) / 2;
+  const nx = (x - c) / (g * 0.48);
+  const ny = (c - y) / (g * 0.34) + 0.05;
+  return Math.pow(nx * nx + ny * ny - 1, 3) - nx * nx * Math.pow(ny, 3) <= 0;
+};
+
+// Per-variant configuration. Delay functions only run for dots the mask keeps
+// visible, so they never need to guard against out-of-pattern positions.
+const variantConfigs = {
+  // Diagonal wave from the top-left corner
+  default: { keyframe: "pixel-scale", duration: 1, delay: (x, y) => 0.05 * (x + y) },
+  // Horizontal wave
+  wave: { keyframe: "pixel-scale", duration: 1, delay: (x) => 0.1 * x },
+  // Vertical wave, top to bottom
+  cascade: { keyframe: "pixel-scale", duration: 1, delay: (_x, y) => 0.12 * y },
+  // Spiral radiating from the center
+  spiral: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    delay: (x, y, g) => {
+      const c = (g - 1) / 2;
+      const distance = Math.hypot(x - c, y - c);
+      const normalizedAngle = (Math.atan2(y - c, x - c) + Math.PI) / (2 * Math.PI);
+      return distance * 0.15 + normalizedAngle * 0.3;
+    },
+  },
+  // Rotating arm that also pulses radially
+  vortex: {
+    keyframe: "pixel-chase",
+    duration: 1.2,
+    delay: (x, y, g) => {
+      const c = (g - 1) / 2;
+      const distance = Math.hypot(x - c, y - c);
+      const normalizedAngle = (Math.atan2(y - c, x - c) + Math.PI) / (2 * Math.PI);
+      return normalizedAngle * 1.2 + distance * 0.1;
+    },
+  },
+  // Chase around the perimeter
+  chase: {
+    keyframe: "pixel-chase",
+    duration: 0.8,
+    mask: edgeMask,
+    delay: (x, y, g) => {
+      const last = g - 1;
+      let order = 0;
+      if (y === 0) order = x;
+      else if (x === last) order = last + y;
+      else if (y === last) order = 2 * last + (last - x);
+      else order = 3 * last + (last - y);
+      return (order / (4 * last)) * 0.8;
+    },
+  },
+  // Whole border pulses together
+  frame: { keyframe: "pixel-chase", duration: 1, mask: edgeMask, delay: () => 0 },
+  // Rain falling from the top, each column offset
+  rain: { keyframe: "pixel-rain", duration: 0.8, delay: (x, y) => y * 0.1 + x * 0.05 },
+  // Sharp scanline sweeping downward
+  scan: { keyframe: "pixel-chase", duration: 1.2, delay: (_x, y) => y * 0.15 },
+  // Concentric rings radiating from the center
+  ripple: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    delay: (x, y, g) => {
+      const c = (g - 1) / 2;
+      return Math.hypot(x - c, y - c) * 0.18;
+    },
+  },
+  // Diamond-shaped rings (manhattan distance) from the center
+  diamond: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    delay: (x, y, g) => {
+      const c = (g - 1) / 2;
+      return (Math.abs(x - c) + Math.abs(y - c)) * 0.12;
+    },
+  },
+  // Cross + diagonals radiating from the center
+  star: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    mask: starMask,
+    delay: (x, y, g) => {
+      const c = Math.floor(g / 2);
+      return Math.max(Math.abs(x - c), Math.abs(y - c)) * 0.12;
+    },
+  },
+  // Diagonal cross (X) radiating from the center
+  saltire: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    mask: saltireMask,
+    delay: (x, y, g) => {
+      const c = Math.floor(g / 2);
+      return Math.max(Math.abs(x - c), Math.abs(y - c)) * 0.12;
+    },
+  },
+  // Center row and column animate outward from the center
+  crosshair: {
+    keyframe: "pixel-crosshair",
+    duration: 0.6,
+    mask: crosshairMask,
+    delay: (x, y, g) => {
+      const c = Math.floor(g / 2);
+      return (y === c ? Math.abs(x - c) : Math.abs(y - c)) * 0.1;
+    },
+  },
+  // Collapse inward from all four corners
+  corners: {
+    keyframe: "pixel-scale",
+    duration: 1,
+    delay: (x, y, g) => {
+      const last = g - 1;
+      const toX = Math.min(x, last - x);
+      const toY = Math.min(y, last - y);
+      return Math.hypot(toX, toY) * 0.15;
+    },
+  },
+  // Alternating checkerboard pulse
+  checker: { keyframe: "pixel-scale", duration: 1, delay: (x, y) => ((x + y) % 2) * 0.5 },
+  // Snake (alternating direction per row)
+  snake: {
+    keyframe: "pixel-scale",
+    duration: 1.5,
+    delay: (x, y, g) => {
+      const effectiveX = y % 2 === 0 ? x : g - 1 - x;
+      return (y * g + effectiveX) * 0.05;
+    },
+  },
+  // Radar sweep around the center
+  radar: {
+    keyframe: "pixel-chase",
+    duration: 1.2,
+    delay: (x, y, g) => {
+      const c = (g - 1) / 2;
+      return ((Math.atan2(y - c, x - c) + Math.PI) / (2 * Math.PI)) * 1.2;
+    },
+  },
+  // Every dot breathes together
+  pulse: { keyframe: "pixel-scale", duration: 1, delay: () => 0 },
+  // Whole heart beats together
+  heart: { keyframe: "pixel-beat", duration: 1.2, mask: heartMask, delay: () => 0 },
+} satisfies Record<string, VariantConfig>;
+
+const variants = Object.keys(variantConfigs) as SpinnerVariant[];
+
+type SpinnerVariant = keyof typeof variantConfigs;
 
 type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
   /** Pixel size of each dot. */
@@ -52,7 +206,7 @@ type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
   ariaLabel?: string;
 };
 
-// Respect the user's reduced-motion preference.
+// Respect the user's reduced-motion preference, read on the first render.
 const usePrefersReducedMotion = (): boolean => {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(
     () =>
@@ -71,266 +225,6 @@ const usePrefersReducedMotion = (): boolean => {
   return prefersReducedMotion;
 };
 
-// Heart shape mask via the implicit heart curve, normalized to the grid.
-const isHeartPixel = (x: number, y: number, gridSize: number): boolean => {
-  const center = (gridSize - 1) / 2;
-  const nx = (x - center) / (gridSize * 0.48);
-  const ny = (center - y) / (gridSize * 0.34) + 0.05;
-  return Math.pow(nx * nx + ny * ny - 1, 3) - nx * nx * Math.pow(ny, 3) <= 0;
-};
-
-// Get animation delay (in seconds) based on variant and position
-const getAnimationDelay = (
-  variant: SpinnerVariant,
-  x: number,
-  y: number,
-  gridSize: number,
-): number => {
-  const center = (gridSize - 1) / 2;
-
-  switch (variant) {
-    case "default":
-      // Diagonal wave from top-left
-      return 0.05 * (x + y);
-
-    case "wave":
-      // Horizontal wave
-      return 0.1 * x;
-
-    case "cascade":
-      // Vertical wave, top to bottom
-      return 0.12 * y;
-
-    case "spiral": {
-      // Spiral from center outward
-      const dx = x - center;
-      const dy = y - center;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      const angle = Math.atan2(dy, dx);
-      const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return distance * 0.15 + normalizedAngle * 0.3;
-    }
-
-    case "vortex": {
-      // Rotating arm that also pulses radially
-      const dx = x - center;
-      const dy = y - center;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      const angle = Math.atan2(dy, dx);
-      const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return normalizedAngle * 1.2 + distance * 0.1;
-    }
-
-    case "chase": {
-      // Chase around the perimeter
-      const isTop = y === 0;
-      const isBottom = y === gridSize - 1;
-      const isLeft = x === 0;
-      const isRight = x === gridSize - 1;
-      const isEdge = isTop || isBottom || isLeft || isRight;
-
-      if (!isEdge) return 0;
-
-      let order = 0;
-      if (isTop) order = x;
-      else if (isRight) order = gridSize - 1 + y;
-      else if (isBottom) order = 2 * (gridSize - 1) + (gridSize - 1 - x);
-      else if (isLeft) order = 3 * (gridSize - 1) + (gridSize - 1 - y);
-
-      const perimeter = 4 * (gridSize - 1);
-      return (order / perimeter) * 0.8;
-    }
-
-    case "frame":
-      // Whole border pulses together
-      return 0;
-
-    case "rain":
-      // Rain falling from top, each column offset
-      return y * 0.1 + x * 0.05;
-
-    case "scan":
-      // Sharp scanline sweeping downward
-      return y * 0.15;
-
-    case "ripple": {
-      // Concentric rings radiating from the center
-      const dx = x - center;
-      const dy = y - center;
-      const distance = Math.sqrt(dx * dx + dy * dy);
-      return distance * 0.18;
-    }
-
-    case "diamond": {
-      // Diamond-shaped rings (manhattan distance) from the center
-      const manhattan = Math.abs(x - center) + Math.abs(y - center);
-      return manhattan * 0.12;
-    }
-
-    case "star": {
-      // Star pattern - radiates outward from center along cross and diagonals
-      const centerIdx = Math.floor(gridSize / 2);
-      const dx = x - centerIdx;
-      const dy = y - centerIdx;
-      const isCross = x === centerIdx || y === centerIdx;
-      const isDiagonal = Math.abs(dx) === Math.abs(dy);
-      if (!isCross && !isDiagonal) return 0;
-
-      const dist = Math.max(Math.abs(dx), Math.abs(dy));
-      return dist * 0.12;
-    }
-
-    case "saltire": {
-      // Diagonal cross (X) radiating from the center
-      const centerIdx = Math.floor(gridSize / 2);
-      const dist = Math.max(Math.abs(x - centerIdx), Math.abs(y - centerIdx));
-      return dist * 0.12;
-    }
-
-    case "crosshair": {
-      // Center row and column animate outward from center
-      const centerIdx = Math.floor(gridSize / 2);
-      const isCenterRow = y === centerIdx;
-      const isCenterCol = x === centerIdx;
-      if (!isCenterRow && !isCenterCol) return 0;
-
-      const distFromCenter = isCenterRow
-        ? Math.abs(x - centerIdx)
-        : Math.abs(y - centerIdx);
-      return distFromCenter * 0.1;
-    }
-
-    case "corners": {
-      // Collapse inward from all four corners
-      const last = gridSize - 1;
-      const cornerPoints: [number, number][] = [
-        [0, 0],
-        [last, 0],
-        [0, last],
-        [last, last],
-      ];
-      let nearest = Infinity;
-      for (const [cx, cy] of cornerPoints) {
-        const d = Math.sqrt((x - cx) * (x - cx) + (y - cy) * (y - cy));
-        if (d < nearest) nearest = d;
-      }
-      return nearest * 0.15;
-    }
-
-    case "checker":
-      // Alternating checkerboard pulse
-      return ((x + y) % 2) * 0.5;
-
-    case "snake": {
-      // Snake pattern (alternating direction per row)
-      const effectiveX = y % 2 === 0 ? x : gridSize - 1 - x;
-      return (y * gridSize + effectiveX) * 0.05;
-    }
-
-    case "radar": {
-      // Radar sweep around the center
-      const angle = Math.atan2(y - center, x - center);
-      const normalizedAngle = (angle + Math.PI) / (2 * Math.PI);
-      return normalizedAngle * 1.2;
-    }
-
-    case "pulse":
-      // Every dot breathes together
-      return 0;
-
-    case "heart":
-      // Whole heart beats together
-      return 0;
-
-    default:
-      return 0.05 * (x + y);
-  }
-};
-
-// Get animation name for variant
-const getAnimationName = (variant: SpinnerVariant): string => {
-  switch (variant) {
-    case "chase":
-    case "frame":
-    case "scan":
-    case "radar":
-    case "vortex":
-      return "pixel-chase";
-    case "rain":
-      return "pixel-rain";
-    case "crosshair":
-      return "pixel-crosshair";
-    case "heart":
-      return "pixel-beat";
-    default:
-      return "pixel-scale";
-  }
-};
-
-// Get animation duration (in seconds) for variant
-const getAnimationDuration = (variant: SpinnerVariant): number => {
-  switch (variant) {
-    case "chase":
-    case "rain":
-      return 0.8;
-    case "crosshair":
-      return 0.6;
-    case "snake":
-      return 1.5;
-    case "scan":
-    case "radar":
-    case "vortex":
-      return 1.2;
-    case "heart":
-      return 1.2;
-    default:
-      return 1;
-  }
-};
-
-// Check if pixel should be visible for certain variants
-const shouldShowPixel = (
-  variant: SpinnerVariant,
-  x: number,
-  y: number,
-  gridSize: number,
-): boolean => {
-  if (variant === "chase" || variant === "frame") {
-    const isTop = y === 0;
-    const isBottom = y === gridSize - 1;
-    const isLeft = x === 0;
-    const isRight = x === gridSize - 1;
-    return isTop || isBottom || isLeft || isRight;
-  }
-
-  if (variant === "star") {
-    const centerIdx = Math.floor(gridSize / 2);
-    const dx = x - centerIdx;
-    const dy = y - centerIdx;
-    const isCross = x === centerIdx || y === centerIdx;
-    const isDiagonal = Math.abs(dx) === Math.abs(dy);
-    const isCorner =
-      (x === 0 || x === gridSize - 1) && (y === 0 || y === gridSize - 1);
-    return (isCross || isDiagonal) && !isCorner;
-  }
-
-  if (variant === "saltire") {
-    const centerIdx = Math.floor(gridSize / 2);
-    return Math.abs(x - centerIdx) === Math.abs(y - centerIdx);
-  }
-
-  if (variant === "crosshair") {
-    const centerIdx = Math.floor(gridSize / 2);
-    return x === centerIdx || y === centerIdx;
-  }
-
-  if (variant === "heart") {
-    return isHeartPixel(x, y, gridSize);
-  }
-
-  return true;
-};
-
 export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
   (
     {
@@ -346,65 +240,47 @@ export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
     },
     ref,
   ) => {
-    const prefersReducedMotion = usePrefersReducedMotion();
-    const animate = !prefersReducedMotion;
+    const animate = !usePrefersReducedMotion();
     const safeSpeed = speed > 0 ? speed : 1;
+    const range = Array.from({ length: gridSize }, (_, i) => i);
 
-    const squareSize = `${size}px`;
-    const gridArray = Array.from({ length: gridSize }, (_, i) => i);
-
-    const animationName = getAnimationName(variant);
-    const duration = getAnimationDuration(variant) / safeSpeed;
-    const hueRotate = `hue-rotate ${10 / safeSpeed}s linear infinite`;
+    const config = variantConfigs[variant];
+    const duration = config.duration / safeSpeed;
+    // Rainbow runs without a delay so every dot cycles hue in sync.
+    const rainbowAnimation = rainbow ? `, hue-rotate ${10 / safeSpeed}s linear infinite` : "";
 
     return (
       <div
         ref={ref}
         role="status"
         aria-label={ariaLabel}
-        className={cn("inline-flex flex-col gap-0", className)}
-        style={
-          {
-            "--square-size": squareSize,
-            "--spinner-color": color,
-          } as CSSProperties
-        }
+        className={cn("inline-flex flex-col", className)}
+        style={{ "--square-size": `${size}px`, "--spinner-color": color } as CSSProperties}
         {...props}
       >
-        {gridArray.map((y) => (
-          <div key={y} className="flex gap-0">
-            {gridArray.map((x) => {
-              const show = shouldShowPixel(variant, x, y, gridSize);
-              const delay = getAnimationDelay(variant, x, y, gridSize) / safeSpeed;
-              return (
-                <div
-                  key={x}
-                  className="relative inline-block"
-                  style={{
-                    width: "var(--square-size)",
-                    height: "var(--square-size)",
-                    animation: rainbow && animate ? hueRotate : undefined,
-                  }}
-                >
-                  {show && (
-                    <div
-                      className="absolute top-0 left-0"
-                      style={{
-                        width: "var(--square-size)",
-                        height: "var(--square-size)",
-                        backgroundColor: "var(--spinner-color)",
-                        boxShadow:
-                          "0 0 10px var(--spinner-color), 0 0 20px var(--spinner-color), 0 0 40px var(--spinner-color)",
-                        animation: animate
-                          ? `${animationName} ${duration}s linear infinite`
-                          : undefined,
-                        animationDelay: animate ? `${delay}s` : undefined,
-                      }}
-                    />
-                  )}
-                </div>
-              );
-            })}
+        {range.map((y) => (
+          <div key={y} className="flex">
+            {range.map((x) => (
+              <div
+                key={x}
+                className="relative"
+                style={{ width: "var(--square-size)", height: "var(--square-size)" }}
+              >
+                {(config.mask?.(x, y, gridSize) ?? true) && (
+                  <div
+                    className="absolute inset-0"
+                    style={{
+                      backgroundColor: "var(--spinner-color)",
+                      boxShadow:
+                        "0 0 10px var(--spinner-color), 0 0 20px var(--spinner-color), 0 0 40px var(--spinner-color)",
+                      animation: animate
+                        ? `${config.keyframe} ${duration}s linear ${config.delay(x, y, gridSize) / safeSpeed}s infinite${rainbowAnimation}`
+                        : undefined,
+                    }}
+                  />
+                )}
+              </div>
+            ))}
           </div>
         ))}
       </div>

--- a/content/spinner-pixel-grid/spinner-pixel-grid.tsx
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.tsx
@@ -87,6 +87,7 @@ const variantConfigs = {
     mask: edgeMask,
     delay: (x, y, g) => {
       const last = g - 1;
+      if (last === 0) return 0;
       let order = 0;
       if (y === 0) order = x;
       else if (x === last) order = last + y;
@@ -188,7 +189,10 @@ const variantConfigs = {
 
 const variants = Object.keys(variantConfigs) as SpinnerVariant[];
 
+const shapes = ["square", "circle"] as const;
+
 type SpinnerVariant = keyof typeof variantConfigs;
+type SpinnerShape = (typeof shapes)[number];
 
 type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
   /** Pixel size of each dot. */
@@ -196,8 +200,12 @@ type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
   /** Number of dots per row/column. */
   gridSize?: number;
   variant?: SpinnerVariant;
+  /** Shape of each dot. */
+  shape?: SpinnerShape;
   /** Dot color. Any CSS color; defaults to the inherited text color. */
   color?: string;
+  /** Render the neon glow around each dot. */
+  glow?: boolean;
   /** Animation speed multiplier. 2 = twice as fast, 0.5 = half speed. */
   speed?: number;
   /** Cycle the hue of every dot for a rainbow effect. */
@@ -232,7 +240,9 @@ export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
       size = 8,
       gridSize = 3,
       variant = "default",
+      shape = "square",
       color = "currentColor",
+      glow = true,
       speed = 1,
       rainbow = false,
       ariaLabel = "Loading",
@@ -271,8 +281,10 @@ export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
                     className="absolute inset-0"
                     style={{
                       backgroundColor: "var(--spinner-color)",
-                      boxShadow:
-                        "0 0 10px var(--spinner-color), 0 0 20px var(--spinner-color), 0 0 40px var(--spinner-color)",
+                      borderRadius: shape === "circle" ? "50%" : undefined,
+                      boxShadow: glow
+                        ? "0 0 10px var(--spinner-color), 0 0 20px var(--spinner-color), 0 0 40px var(--spinner-color)"
+                        : undefined,
                       animation: animate
                         ? `${config.keyframe} ${duration}s linear ${config.delay(x, y, gridSize) / safeSpeed}s infinite${rainbowAnimation}`
                         : undefined,
@@ -290,5 +302,5 @@ export const SpinnerPixelGrid = forwardRef<HTMLDivElement, SpinnerProps>(
 
 SpinnerPixelGrid.displayName = "SpinnerPixelGrid";
 
-export { variants as spinnerVariants };
-export type { SpinnerVariant };
+export { variants as spinnerVariants, shapes as spinnerShapes };
+export type { SpinnerVariant, SpinnerShape };

--- a/content/spinner-pixel-grid/spinner-pixel-grid.tsx
+++ b/content/spinner-pixel-grid/spinner-pixel-grid.tsx
@@ -54,7 +54,11 @@ type SpinnerProps = HTMLAttributes<HTMLDivElement> & {
 
 // Respect the user's reduced-motion preference.
 const usePrefersReducedMotion = (): boolean => {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
 
   useEffect(() => {
     const query = window.matchMedia("(prefers-reduced-motion: reduce)");


### PR DESCRIPTION
## Summary

Expands the **Spinner Pixel Grid** content component from **8 → 20** animation variants, inspired by classic dot-matrix loader collections.

### Context / licensing note
This was prompted by a request to mirror the examples at https://dotmatrix.zzzzshawn.cloud/. That site advertises itself as "open-source," but its repo (`zzzzshawn/matrix`) actually ships a **custom proprietary license** that explicitly forbids including its components in another component library/collection — which is exactly what uicapsule is. So rather than copying their code, **these are all original implementations** built on our existing per-cell-delay grid architecture. No code was copied.

### New variants (12)
`cascade`, `vortex`, `frame`, `scan`, `ripple`, `diamond`, `saltire`, `corners`, `checker`, `radar`, `pulse`, `heart`

- **heart** uses an implicit heart-curve mask (generalizes across grid sizes) plus a new `pixel-beat` double-thump keyframe.
- **radar** / **vortex** are angle-driven sweeps; **ripple** / **diamond** / **corners** are distance-field waves; **frame** / **saltire** are masked outlines; **checker** / **pulse** / **scan** / **cascade** are timing patterns.

### Other changes
- New `pixel-beat` keyframe in the CSS.
- Preview updated to showcase all 20 variants in a responsive grid (was 8 variants × 3 sizes).

### Verification
- `pnpm --filter web typecheck` passes.
- `pnpm lint` passes (no new warnings on changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uwa8afUYWzyjrHun4UX7sW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uwa8afUYWzyjrHun4UX7sW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only content component changes with no auth or data paths; the main consumer risk is breaking callers that relied on the old always-rainbow look or a smaller variant set.
> 
> **Overview**
> **Spinner Pixel Grid** grows from 8 to **20** animation variants and replaces scattered switch logic with a single **`variantConfigs`** table (keyframe, duration, per-cell delay, optional **masks**). New patterns include **cascade**, **vortex**, **frame**, **scan**, **ripple**, **diamond**, **saltire**, **corners**, **checker**, **radar**, **pulse**, and **heart** (implicit heart-curve mask plus new **`pixel-beat`** CSS).
> 
> The component API adds **`shape`**, **`color`**, **`glow`**, **`speed`**, **`rainbow`**, and **`ariaLabel`**, with **`role="status"`** and **`prefers-reduced-motion`** handling (animations off when requested). Styling moves from hard-coded yellow glow to **`--spinner-color`**; rainbow is opt-in instead of always on.
> 
> The **preview** is now an interactive demo: sticky toggles for glow, rainbow, and square/circle shape, and a responsive grid of all variants (replacing the old variant × size matrix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de383ac54bb4cc62fe43aba6468233e0a1ddf6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 12 new dot-matrix variants to Spinner Pixel Grid (8 → 20) and updates the preview to a responsive grid with shape, glow, and rainbow toggles; all implementations are original. Collapses per-variant logic into a single `variantConfigs` table for simpler maintenance.

- New Features
  - New variants: cascade, vortex, frame, scan, ripple, diamond, saltire, corners, checker, radar, pulse, heart.
  - New props: `shape` (`square` | `circle`), `glow` (default true), `color` (defaults to `currentColor`), `speed` multiplier, `rainbow` hue cycle, `ariaLabel` with `role="status"`; honors `prefers-reduced-motion` and reads it on first render to prevent a flash.
  - Added `pixel-beat` keyframe; introduced angle/radial/Manhattan timing patterns, border/diagonal masks, and a grid-size–agnostic heart mask.

- Bug Fixes
  - Guarded `chase` delay when `gridSize=1` to avoid NaN `animation-delay`.
  - Preview shape toggle now sets `aria-pressed` for better accessibility.

<sup>Written for commit 2de383ac54bb4cc62fe43aba6468233e0a1ddf6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

