### PR TITLE
feat: drum-picker — iOS time-picker wheel

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@uicapsule/background-shapes": "workspace:*",
     "@uicapsule/card-stack": "workspace:*",
     "@uicapsule/carousel-3d": "workspace:*",
+    "@uicapsule/drum-picker": "workspace:*",
     "@uicapsule/dynamic-ai-composer": "workspace:*",
     "@uicapsule/dynamic-island": "workspace:*",
     "@uicapsule/expanding-header-menu": "workspace:*",

--- a/content/drum-picker/drum-picker.tsx
+++ b/content/drum-picker/drum-picker.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, type FC } from "react";
+import {
+  motion,
+  useMotionValue,
+  useMotionValueEvent,
+  useTransform,
+  type MotionValue,
+} from "motion/react";
+
+const ITEM_HEIGHT = 38;
+const VISIBLE_ITEMS = 7;
+const WHEEL_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
+const CENTER_OFFSET = (WHEEL_HEIGHT - ITEM_HEIGHT) / 2;
+
+const HOURS = Array.from({ length: 12 }, (_, index) => String(index + 1));
+const MINUTES = Array.from({ length: 60 }, (_, index) => String(index).padStart(2, "0"));
+const PERIODS = ["AM", "PM"];
+
+type WheelItemProps = {
+  y: MotionValue<number>;
+  index: number;
+  label: string;
+  align: "left" | "center" | "right";
+};
+
+const WheelItem: FC<WheelItemProps> = ({ y, index, label, align }) => {
+  // Distance of this item from the selection line, in items (-3..3 visible).
+  const distance = useTransform(y, (value) => (value + index * ITEM_HEIGHT) / ITEM_HEIGHT);
+  const rotateX = useTransform(distance, [-3.5, 0, 3.5], [-62, 0, 62]);
+  const opacity = useTransform(distance, [-3.5, -2, 0, 2, 3.5], [0, 0.35, 1, 0.35, 0]);
+  const scale = useTransform(distance, [-3.5, 0, 3.5], [0.82, 1, 0.82]);
+
+  return (
+    <motion.div
+      style={{
+        height: ITEM_HEIGHT,
+        rotateX,
+        opacity,
+        scale,
+        transformPerspective: 780,
+      }}
+      className={`flex items-center text-[21px] text-white tabular-nums ${
+        align === "right"
+          ? "justify-end pr-2"
+          : align === "left"
+            ? "justify-start pl-2"
+            : "justify-center"
+      }`}
+    >
+      {label}
+    </motion.div>
+  );
+};
+
+type WheelProps = {
+  items: string[];
+  initialIndex: number;
+  onChange: (index: number) => void;
+  width: string;
+  align: "left" | "center" | "right";
+};
+
+const Wheel: FC<WheelProps> = ({ items, initialIndex, onChange, width, align }) => {
+  const y = useMotionValue(-initialIndex * ITEM_HEIGHT);
+
+  useMotionValueEvent(y, "change", (value) => {
+    const index = Math.round(-value / ITEM_HEIGHT);
+    onChange(Math.min(items.length - 1, Math.max(0, index)));
+  });
+
+  return (
+    <div className={`relative ${width}`} style={{ height: WHEEL_HEIGHT }}>
+      <div className="absolute inset-0 overflow-hidden" style={{ perspective: 780 }}>
+        <motion.div
+          drag="y"
+          style={{ y, paddingTop: CENTER_OFFSET }}
+          dragConstraints={{
+            top: -(items.length - 1) * ITEM_HEIGHT,
+            bottom: 0,
+          }}
+          dragElastic={0.12}
+          dragTransition={{
+            power: 0.55,
+            timeConstant: 220,
+            bounceStiffness: 320,
+            bounceDamping: 28,
+            modifyTarget: (target) => Math.round(target / ITEM_HEIGHT) * ITEM_HEIGHT,
+          }}
+          className="cursor-grab active:cursor-grabbing"
+        >
+          {items.map((label, index) => (
+            <WheelItem key={label} y={y} index={index} label={label} align={align} />
+          ))}
+        </motion.div>
+      </div>
+    </div>
+  );
+};
+
+export const DrumPicker = () => {
+  const [hourIndex, setHourIndex] = useState(8);
+  const [minuteIndex, setMinuteIndex] = useState(41);
+  const [periodIndex, setPeriodIndex] = useState(0);
+
+  const hour = HOURS[hourIndex] ?? "9";
+  const minute = MINUTES[minuteIndex] ?? "41";
+  const period = PERIODS[periodIndex] ?? "AM";
+
+  return (
+    <div className="w-[340px] rounded-[32px] bg-[#161618] p-6 shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none">
+      <div className="flex items-baseline justify-between">
+        <p className="text-[17px] font-semibold text-white">Alarm</p>
+        <p className="text-[13px] text-white/40 tabular-nums">
+          {hour}:{minute} {period}
+        </p>
+      </div>
+
+      <div className="relative mt-4">
+        {/* Selection lens */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 rounded-xl bg-white/[0.07]"
+          style={{ height: ITEM_HEIGHT }}
+        />
+        {/* Edge fog */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 z-10 h-16 bg-gradient-to-b from-[#161618] to-transparent"
+        />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-16 bg-gradient-to-t from-[#161618] to-transparent"
+        />
+
+        <div className="flex items-stretch justify-center gap-1 px-6">
+          <Wheel
+            items={HOURS}
+            initialIndex={8}
+            onChange={setHourIndex}
+            width="w-16"
+            align="right"
+          />
+          <Wheel
+            items={MINUTES}
+            initialIndex={41}
+            onChange={setMinuteIndex}
+            width="w-16"
+            align="center"
+          />
+          <Wheel
+            items={PERIODS}
+            initialIndex={0}
+            onChange={setPeriodIndex}
+            width="w-14"
+            align="left"
+          />
+        </div>
+      </div>
+
+      <p className="mt-4 text-center text-[11px] text-white/30">Flick a wheel — it snaps to rest</p>
+    </div>
+  );
+};

--- a/content/drum-picker/meta.json
+++ b/content/drum-picker/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Drum Picker",
+  "description": "The iOS time-picker wheel on the web — 3D cylinder, momentum flicks, detent snapping, edge fog.",
+  "tags": ["mobile", "forms", "skeuomorphism"]
+}

--- a/content/drum-picker/package.json
+++ b/content/drum-picker/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uicapsule/drum-picker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/drum-picker/preview.tsx
+++ b/content/drum-picker/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { DrumPicker } from "./drum-picker";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#232329_0%,#121215_55%,#070709_100%)] p-5">
+      <DrumPicker />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@uicapsule/carousel-3d':
         specifier: workspace:*
         version: link:../../content/carousel-3d
+      '@uicapsule/drum-picker':
+        specifier: workspace:*
+        version: link:../../content/drum-picker
       '@uicapsule/dynamic-ai-composer':
         specifier: workspace:*
         version: link:../../content/dynamic-ai-composer
@@ -392,6 +395,25 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/drum-picker:
+    dependencies:
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/dynamic-ai-composer:
     dependencies:


### PR DESCRIPTION
The iOS drum wheel, properly:

- 3D cylinder via per-item `useTransform` off the column's y (rotateX/opacity/scale by distance from the selection line)
- Real momentum flicks: `dragTransition` inertia w/ `modifyTarget` snapping to item detents
- Selection lens + edge fog, live header readout, hours/minutes/AM-PM columns

Verified in-browser: flick → inertia → detent snap → header updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an iOS-style drum time picker with a 3D wheel, momentum scrolling, and snapping. Ships as `@uicapsule/drum-picker` with a preview for quick testing.

- **New Features**
  - 3D cylinder effect per item (rotateX/opacity/scale by distance).
  - Inertial flicks with detent snapping via drag transition.
  - Selection lens, edge fog, and live header readout.
  - Three columns: hours, minutes, and AM/PM.

- **Dependencies**
  - Add `@uicapsule/drum-picker` to `apps/web`.
  - Add `motion@^12.40.0` to the new package; lockfile updated.

<sup>Written for commit 8bb02e7799c6f217eb56213a5e423969e2d19bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

