### PR TITLE
feat: pinch-grid — iOS Photos pinch-zoom reflow

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@uicapsule/light-dark-toggle": "workspace:*",
     "@uicapsule/like-button": "workspace:*",
     "@uicapsule/particle-orb": "workspace:*",
+    "@uicapsule/pinch-grid": "workspace:*",
     "@uicapsule/radial-slider": "workspace:*",
     "@uicapsule/sidebar": "workspace:*",
     "@uicapsule/snail-timer": "workspace:*",

--- a/content/pinch-grid/meta.json
+++ b/content/pinch-grid/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Pinch Grid",
+  "description": "iOS Photos pinch-zoom — the grid reflows between column counts as every tile springs to its new cell.",
+  "tags": ["mobile", "effects", "navigation"]
+}

--- a/content/pinch-grid/package.json
+++ b/content/pinch-grid/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/pinch-grid",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/pinch-grid/pinch-grid.tsx
+++ b/content/pinch-grid/pinch-grid.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { ZoomIn, ZoomOut } from "lucide-react";
+import { motion } from "motion/react";
+
+// Abstract "photos" — hue pairs rendered as gradients so the capsule ships no assets.
+const TILES = Array.from({ length: 30 }, (_, index) => {
+  const hue = (index * 47) % 360;
+  const hueB = (hue + 40 + ((index * 13) % 50)) % 360;
+  const angle = (index * 67) % 360;
+  return {
+    id: `tile-${index}`,
+    gradient: `linear-gradient(${angle}deg, hsl(${hue} 65% 52%), hsl(${hueB} 70% 30%))`,
+  };
+});
+
+const LEVELS = [7, 5, 3, 1] as const;
+const PINCH_STEP = 90;
+
+export const PinchGrid = () => {
+  const [level, setLevel] = useState(1);
+  const pinchDebtRef = useRef(0);
+
+  const zoom = useCallback((direction: 1 | -1) => {
+    setLevel((previous) => Math.min(LEVELS.length - 1, Math.max(0, previous + direction)));
+  }, []);
+
+  const columns = LEVELS[level] ?? 5;
+
+  return (
+    <div
+      className="flex h-[600px] w-[400px] flex-col overflow-hidden rounded-[36px] bg-[#0b0b0d] shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none"
+      onWheel={(event) => {
+        // Trackpad pinches arrive as ctrl+wheel.
+        if (!event.ctrlKey && !event.metaKey) return;
+        pinchDebtRef.current += event.deltaY;
+        if (pinchDebtRef.current > PINCH_STEP) {
+          // Pinch in → zoom out → more columns.
+          pinchDebtRef.current = 0;
+          zoom(-1);
+        } else if (pinchDebtRef.current < -PINCH_STEP) {
+          pinchDebtRef.current = 0;
+          zoom(1);
+        }
+      }}
+    >
+      <div className="flex items-center justify-between px-5 pt-5 pb-3">
+        <div>
+          <p className="text-[17px] font-semibold text-white">Library</p>
+          <p className="text-[12px] text-white/40">June 2026</p>
+        </div>
+        <div className="flex gap-1.5">
+          <button
+            type="button"
+            aria-label="Zoom out"
+            onClick={() => zoom(-1)}
+            disabled={level === 0}
+            className="grid size-9 place-items-center rounded-full bg-white/10 text-white/70 transition-colors hover:bg-white/15 hover:text-white disabled:opacity-40"
+          >
+            <ZoomOut className="size-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="Zoom in"
+            onClick={() => zoom(1)}
+            disabled={level >= LEVELS.length - 1}
+            className="grid size-9 place-items-center rounded-full bg-white/10 text-white/70 transition-colors hover:bg-white/15 hover:text-white disabled:opacity-40"
+          >
+            <ZoomIn className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-hidden px-1.5 pb-1.5">
+        <motion.div
+          className="grid h-full content-start gap-1"
+          style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+        >
+          {TILES.map((tile) => (
+            <motion.div
+              key={tile.id}
+              layout
+              transition={{ type: "spring", duration: 0.55, bounce: 0.18 }}
+              className="aspect-square rounded-[3px]"
+              style={{ background: tile.gradient }}
+            />
+          ))}
+        </motion.div>
+      </div>
+
+      <p className="pb-4 text-center text-[11px] text-white/30">
+        Pinch the trackpad — or use the zoom buttons
+      </p>
+    </div>
+  );
+};

--- a/content/pinch-grid/preview.tsx
+++ b/content/pinch-grid/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { PinchGrid } from "./pinch-grid";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#1d1f26_0%,#0f1015_55%,#06070a_100%)] p-5">
+      <PinchGrid />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@uicapsule/particle-orb':
         specifier: workspace:*
         version: link:../../content/particle-orb
+      '@uicapsule/pinch-grid':
+        specifier: workspace:*
+        version: link:../../content/pinch-grid
       '@uicapsule/radial-slider':
         specifier: workspace:*
         version: link:../../content/radial-slider
@@ -716,6 +719,28 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/pinch-grid:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/radial-slider:
     dependencies:


### PR DESCRIPTION
Photos-style zoom levels (7/5/3/1 columns):

- Trackpad pinch (ctrl+wheel) w/ accumulation threshold, plus zoom buttons
- Every tile springs to its new cell via motion layout on grid-template change
- Asset-free: tiles are seeded hue-pair gradients

Verified in-browser: zoom both directions, reflow animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS Photos–style pinch-zoom grid that reflows between 7/5/3/1 columns with spring animations. Introduces the `@uicapsule/pinch-grid` capsule and a preview, with trackpad pinch and zoom buttons.

- **New Features**
  - `PinchGrid` component with spring reflow on grid-template changes.
  - Ctrl+wheel pinch handling with threshold; zoom in/out buttons.
  - Asset-free tiles using hue-pair gradients.

- **Dependencies**
  - Added `lucide-react` and `motion`.
  - Registered `@uicapsule/pinch-grid` in `apps/web` and exported `./preview`.

<sup>Written for commit ddd22593a11e6e92db34b7748fa27b32f7f29cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

