### PR TITLE
feat: passcode-screen — iOS lock screen

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@uicapsule/light-dark-toggle": "workspace:*",
     "@uicapsule/like-button": "workspace:*",
     "@uicapsule/particle-orb": "workspace:*",
+    "@uicapsule/passcode-screen": "workspace:*",
     "@uicapsule/radial-slider": "workspace:*",
     "@uicapsule/sidebar": "workspace:*",
     "@uicapsule/snail-timer": "workspace:*",

--- a/content/passcode-screen/meta.json
+++ b/content/passcode-screen/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Passcode Screen",
+  "description": "iOS lock screen passcode — keypad ripple, dots that pop as you type, the wrong-code shake, and an unlock reveal.",
+  "tags": ["mobile", "forms", "skeuomorphism"]
+}

--- a/content/passcode-screen/package.json
+++ b/content/passcode-screen/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/passcode-screen",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/passcode-screen/passcode-screen.tsx
+++ b/content/passcode-screen/passcode-screen.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Delete, Lock, LockOpen } from "lucide-react";
+import { AnimatePresence, motion, useAnimate } from "motion/react";
+
+const CORRECT_CODE = "1234";
+const CODE_LENGTH = 4;
+
+const KEYS: { digit: string; letters: string }[] = [
+  { digit: "1", letters: "" },
+  { digit: "2", letters: "ABC" },
+  { digit: "3", letters: "DEF" },
+  { digit: "4", letters: "GHI" },
+  { digit: "5", letters: "JKL" },
+  { digit: "6", letters: "MNO" },
+  { digit: "7", letters: "PQRS" },
+  { digit: "8", letters: "TUV" },
+  { digit: "9", letters: "WXYZ" },
+];
+
+export const PasscodeScreen = () => {
+  const [code, setCode] = useState("");
+  const [unlocked, setUnlocked] = useState(false);
+  const [scope, animate] = useAnimate();
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => timers.forEach(clearTimeout);
+  }, []);
+
+  const queue = useCallback((callback: () => void, delay: number) => {
+    timersRef.current.push(setTimeout(callback, delay));
+  }, []);
+
+  const pressDigit = useCallback(
+    (digit: string) => {
+      if (unlocked) return;
+      setCode((previous) => {
+        if (previous.length >= CODE_LENGTH) return previous;
+        const next = previous + digit;
+        if (next.length === CODE_LENGTH) {
+          if (next === CORRECT_CODE) {
+            queue(() => {
+              setUnlocked(true);
+              queue(() => {
+                setUnlocked(false);
+                setCode("");
+              }, 2400);
+            }, 250);
+          } else {
+            queue(() => {
+              if (scope.current) {
+                void animate(
+                  scope.current,
+                  { x: [0, -14, 14, -10, 10, -5, 5, 0] },
+                  { duration: 0.45, ease: "easeInOut" },
+                );
+              }
+              queue(() => setCode(""), 350);
+            }, 200);
+          }
+        }
+        return next;
+      });
+    },
+    [animate, queue, scope, unlocked],
+  );
+
+  return (
+    <div className="relative h-[620px] w-[340px] overflow-hidden rounded-[44px] bg-[#0c0e18] shadow-2xl shadow-black/60 ring-8 ring-black select-none">
+      {/* Wallpaper */}
+      <motion.div
+        aria-hidden
+        className="absolute inset-0"
+        animate={{ opacity: unlocked ? 1 : 0.55 }}
+        transition={{ duration: 0.6 }}
+      >
+        <div className="absolute -top-16 -right-20 size-72 rounded-full bg-[#6366f1]/40 blur-3xl" />
+        <div className="absolute bottom-10 -left-16 size-64 rounded-full bg-[#06b6d4]/30 blur-3xl" />
+      </motion.div>
+
+      <div className="relative flex h-full flex-col items-center px-8 pt-16">
+        <motion.div
+          key={unlocked ? "open" : "closed"}
+          initial={{ scale: 0.7, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ type: "spring", duration: 0.45, bounce: 0.45 }}
+          className="text-white"
+        >
+          {unlocked ? <LockOpen className="size-7" /> : <Lock className="size-7 opacity-80" />}
+        </motion.div>
+
+        <AnimatePresence mode="wait" initial={false}>
+          {unlocked ? (
+            <motion.div
+              key="welcome"
+              initial={{ opacity: 0, y: 14, filter: "blur(6px)" }}
+              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+              exit={{ opacity: 0 }}
+              transition={{ type: "spring", duration: 0.5, bounce: 0.2 }}
+              className="mt-8 text-center"
+            >
+              <p className="text-[22px] font-semibold text-white">Welcome back</p>
+              <p className="mt-1 text-[13px] text-white/50">Unlocked</p>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="entry"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0, scale: 0.94, filter: "blur(6px)" }}
+              transition={{ duration: 0.3 }}
+              className="flex flex-col items-center"
+            >
+              <p className="mt-5 text-[16px] font-medium text-white">Enter Passcode</p>
+
+              <div ref={scope} className="mt-6 flex gap-5">
+                {Array.from({ length: CODE_LENGTH }, (_, index) => (
+                  <motion.span
+                    key={index}
+                    animate={{
+                      scale: index === code.length - 1 ? [1.4, 1] : 1,
+                      backgroundColor:
+                        index < code.length ? "rgba(255,255,255,1)" : "rgba(255,255,255,0)",
+                    }}
+                    transition={{ duration: 0.18 }}
+                    className="size-3.5 rounded-full ring-1 ring-white/80"
+                  />
+                ))}
+              </div>
+
+              <div className="mt-9 grid grid-cols-3 gap-x-6 gap-y-4">
+                {KEYS.map((key) => (
+                  <motion.button
+                    type="button"
+                    key={key.digit}
+                    onClick={() => pressDigit(key.digit)}
+                    whileTap={{ backgroundColor: "rgba(255,255,255,0.35)", scale: 0.96 }}
+                    className="flex size-[68px] flex-col items-center justify-center rounded-full bg-white/10 backdrop-blur-sm transition-colors duration-300"
+                  >
+                    <span className="text-[26px] leading-none font-light text-white">
+                      {key.digit}
+                    </span>
+                    <span className="mt-0.5 h-3 text-[9px] font-semibold tracking-[0.15em] text-white/60">
+                      {key.letters}
+                    </span>
+                  </motion.button>
+                ))}
+                <span />
+                <motion.button
+                  type="button"
+                  onClick={() => pressDigit("0")}
+                  whileTap={{ backgroundColor: "rgba(255,255,255,0.35)", scale: 0.96 }}
+                  className="flex size-[68px] items-center justify-center rounded-full bg-white/10 backdrop-blur-sm transition-colors duration-300"
+                >
+                  <span className="text-[26px] font-light text-white">0</span>
+                </motion.button>
+                <button
+                  type="button"
+                  aria-label="Delete digit"
+                  onClick={() => setCode((previous) => previous.slice(0, -1))}
+                  className="flex size-[68px] items-center justify-center text-white/70 transition-colors hover:text-white"
+                >
+                  <Delete className="size-6" />
+                </button>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {!unlocked && (
+          <p className="absolute bottom-7 text-[11px] text-white/30">
+            Try 1234 — anything else shakes
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/content/passcode-screen/preview.tsx
+++ b/content/passcode-screen/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { PasscodeScreen } from "./passcode-screen";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#191c28_0%,#0c0e16_55%,#05060a_100%)] p-5">
+      <PasscodeScreen />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@uicapsule/particle-orb':
         specifier: workspace:*
         version: link:../../content/particle-orb
+      '@uicapsule/passcode-screen':
+        specifier: workspace:*
+        version: link:../../content/passcode-screen
       '@uicapsule/radial-slider':
         specifier: workspace:*
         version: link:../../content/radial-slider
@@ -716,6 +719,28 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/passcode-screen:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/radial-slider:
     dependencies:


### PR DESCRIPTION
Lock screen passcode capsule:

- Keypad keys ripple on press (whileTap flash + settle)
- Dots pop-fill as digits land; wrong code shakes the row and clears
- Correct code (1234) opens the padlock, blurs the keypad away, brightens the wallpaper, auto-resets
- Discoverability hint carries the demo

Verified in-browser: wrong-code shake + clear, unlock + reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS-style passcode lock screen demo with smooth keypad, dot, and unlock animations. Publishes it as `@uicapsule/passcode-screen` and links it in the web app.

- **New Features**
  - `PasscodeScreen` component: keypad ripple on press, dots pop-fill, wrong-code shake + clear.
  - Correct code (1234) unlocks: lock opens, keypad blurs out, wallpaper brightens, auto-reset.
  - Preview via `content/passcode-screen/preview.tsx`.

- **Dependencies**
  - Adds workspace package `@uicapsule/passcode-screen` to `apps/web`.
  - Uses `motion` for animations and `lucide-react` for icons.

<sup>Written for commit d87096582cead8e6c8d4864a7531529e26627a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

