### PR TITLE
feat: siri-edge-glow — Apple Intelligence border glow

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@uicapsule/particle-orb": "workspace:*",
     "@uicapsule/radial-slider": "workspace:*",
     "@uicapsule/sidebar": "workspace:*",
+    "@uicapsule/siri-edge-glow": "workspace:*",
     "@uicapsule/snail-timer": "workspace:*",
     "@uicapsule/spinner-pixel-grid": "workspace:*",
     "@uicapsule/spreadsheet": "workspace:*",

--- a/content/siri-edge-glow/meta.json
+++ b/content/siri-edge-glow/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Siri Edge Glow",
+  "description": "Apple Intelligence border glow — press the side button and animated light bleeds in from every edge of the screen.",
+  "tags": ["mobile", "ai", "effects"]
+}

--- a/content/siri-edge-glow/package.json
+++ b/content/siri-edge-glow/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/siri-edge-glow",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/siri-edge-glow/preview.tsx
+++ b/content/siri-edge-glow/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { SiriEdgeGlow } from "./siri-edge-glow";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#181a22_0%,#0c0d13_55%,#050609_100%)] p-5">
+      <SiriEdgeGlow />
+    </main>
+  );
+};
+
+export default Preview;

--- a/content/siri-edge-glow/siri-edge-glow.tsx
+++ b/content/siri-edge-glow/siri-edge-glow.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+
+const GLOW_CONIC =
+  "conic-gradient(from 0deg, #f472b6, #a78bfa, #38bdf8, #34d399, #fbbf24, #fb7185, #f472b6)";
+
+export const SiriEdgeGlow = () => {
+  const [listening, setListening] = useState(false);
+
+  return (
+    <div className="relative h-[620px] w-[340px] select-none">
+      <div className="relative h-full w-full overflow-hidden rounded-[44px] bg-[#0d0f16] shadow-2xl shadow-black/60 ring-8 ring-black">
+        {/* Mock home content */}
+        <motion.div
+          animate={{ opacity: listening ? 0.7 : 1, scale: listening ? 0.985 : 1 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+          className="absolute inset-0 p-6 pt-14"
+        >
+          <p className="text-[13px] font-medium text-white/40">Tuesday, July 7</p>
+          <p className="mt-1 text-[34px] leading-tight font-semibold tracking-tight text-white">
+            Good
+            <br />
+            morning, Kai
+          </p>
+          <div className="mt-6 space-y-3">
+            {[
+              ["Standup", "9:30 – 9:45 AM"],
+              ["Design crit", "11:00 AM – 12:00 PM"],
+              ["Capsule review", "2:00 – 2:30 PM"],
+            ].map(([title, time]) => (
+              <div key={title} className="rounded-2xl bg-white/[0.06] p-4 ring-1 ring-white/[0.06]">
+                <p className="text-[14px] font-medium text-white">{title}</p>
+                <p className="mt-0.5 text-[12px] text-white/40">{time}</p>
+              </div>
+            ))}
+          </div>
+        </motion.div>
+
+        {/* Edge glow: rotating conic ring masked to the bezel */}
+        <AnimatePresence>
+          {listening && (
+            <motion.div
+              key="glow"
+              aria-hidden
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.55, ease: "easeOut" }}
+              className="pointer-events-none absolute inset-0 overflow-hidden rounded-[36px]"
+              style={{
+                maskImage:
+                  "radial-gradient(ellipse 68% 64% at 50% 50%, transparent 78%, black 97%)",
+                WebkitMaskImage:
+                  "radial-gradient(ellipse 68% 64% at 50% 50%, transparent 78%, black 97%)",
+              }}
+            >
+              <motion.div
+                className="absolute inset-[-45%] blur-2xl"
+                style={{ background: GLOW_CONIC }}
+                animate={{ rotate: 360 }}
+                transition={{ duration: 7, ease: "linear", repeat: Infinity }}
+              />
+              <motion.div
+                className="absolute inset-[-45%] opacity-70 blur-3xl"
+                style={{ background: GLOW_CONIC }}
+                animate={{ rotate: -360, scale: [1, 1.06, 1] }}
+                transition={{
+                  rotate: { duration: 11, ease: "linear", repeat: Infinity },
+                  scale: { duration: 2.4, ease: "easeInOut", repeat: Infinity },
+                }}
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Inner breathing rim */}
+        <AnimatePresence>
+          {listening && (
+            <motion.div
+              key="rim"
+              aria-hidden
+              initial={{ opacity: 0 }}
+              animate={{ opacity: [0.5, 0.9, 0.5] }}
+              exit={{ opacity: 0 }}
+              transition={{ opacity: { duration: 2.4, ease: "easeInOut", repeat: Infinity } }}
+              className="pointer-events-none absolute inset-[3px] rounded-[40px] ring-2 ring-white/25"
+            />
+          )}
+        </AnimatePresence>
+
+        {/* Siri pill */}
+        <div className="absolute inset-x-0 bottom-6 flex justify-center">
+          <AnimatePresence mode="popLayout">
+            {listening ? (
+              <motion.div
+                key="prompt"
+                initial={{ opacity: 0, y: 10, scale: 0.9 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: 10, scale: 0.9 }}
+                transition={{ type: "spring", duration: 0.45, bounce: 0.3 }}
+                className="rounded-full bg-white/12 px-5 py-2.5 text-[14px] text-white backdrop-blur-xl ring-1 ring-white/15"
+              >
+                How can I help?
+              </motion.div>
+            ) : (
+              <motion.p
+                key="hint"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1, transition: { delay: 0.8 } }}
+                exit={{ opacity: 0 }}
+                className="text-[11px] text-white/30"
+              >
+                Press the side button
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {/* Side button */}
+      <motion.button
+        type="button"
+        aria-pressed={listening}
+        aria-label={listening ? "Stop Siri" : "Summon Siri"}
+        onClick={() => setListening((previous) => !previous)}
+        whileTap={{ scale: 0.92, x: 2 }}
+        animate={listening ? { backgroundColor: "#a78bfa" } : { backgroundColor: "#3f3f46" }}
+        className="absolute top-36 -right-[13px] h-20 w-[6px] rounded-r-md"
+      />
+    </div>
+  );
+};

--- a/content/siri-edge-glow/siri-edge-glow.tsx
+++ b/content/siri-edge-glow/siri-edge-glow.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Sparkles } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 
 const GLOW_CONIC =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@uicapsule/sidebar':
         specifier: workspace:*
         version: link:../../content/sidebar
+      '@uicapsule/siri-edge-glow':
+        specifier: workspace:*
+        version: link:../../content/siri-edge-glow
       '@uicapsule/snail-timer':
         specifier: workspace:*
         version: link:../../content/snail-timer
@@ -744,6 +747,28 @@ importers:
       lucide-react:
         specifier: ^1.16.0
         version: 1.16.0(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+
+  content/siri-edge-glow:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6


### PR DESCRIPTION
Press the (purple-lit) side button:

- Dual counter-rotating conic gradients, blurred and masked to the screen rim via radial mask — light bleeds in from every edge
- Breathing scale + inner rim pulse while listening
- Content dims/settles back 1.5%, 'How can I help?' pill springs in
- Toggle off recedes cleanly

Verified in-browser: on/off, rim tightness tuned against the real effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@uicapsule/siri-edge-glow`, a Siri-style edge glow that lights the screen border when the side button is pressed. Includes an interactive `SiriEdgeGlow` component with rotating gradients, a breathing rim, and a "How can I help?" pill.

- **New Features**
  - New package `@uicapsule/siri-edge-glow` exposing `SiriEdgeGlow` and `./preview`.
  - Side button toggle: dims/scales content ~1.5%, shows prompt pill, clean exit.
  - Dual counter-rotating conic gradients masked to the bezel with an inner rim pulse.

- **Dependencies**
  - Add `@uicapsule/siri-edge-glow` to `apps/web` workspace deps.
  - Lockfile updated for `motion` and `lucide-react`.

<sup>Written for commit 107e30294d058c3615c4f25ff7648b8b52c7bae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

