### PR TITLE
feat: imessage-send — send morph + tapbacks

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@uicapsule/filter-bar": "workspace:*",
     "@uicapsule/geometric-orb": "workspace:*",
     "@uicapsule/gradient-orb": "workspace:*",
+    "@uicapsule/imessage-send": "workspace:*",
     "@uicapsule/infinite-grid": "workspace:*",
     "@uicapsule/ios-volume-slider": "workspace:*",
     "@uicapsule/light-dark-toggle": "workspace:*",

--- a/content/imessage-send/imessage-send.tsx
+++ b/content/imessage-send/imessage-send.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowUp, ChevronLeft, Video } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+
+type Message = {
+  id: number;
+  text: string;
+  sent: boolean;
+  reaction?: string;
+};
+
+const INITIAL_MESSAGES: Message[] = [
+  { id: 1, text: "Ready to see the send animation?", sent: false },
+  { id: 2, text: "Born ready", sent: true },
+  { id: 3, text: "Type something — or long-press a bubble for tapbacks", sent: false },
+];
+
+const SUGGESTIONS = ["On my way!", "Ship it 🚀", "😂😂😂"];
+const TAPBACKS = ["❤️", "👍", "😂", "‼️", "❓"];
+const LONG_PRESS_MS = 380;
+
+export const ImessageSend = () => {
+  const [messages, setMessages] = useState<Message[]>(INITIAL_MESSAGES);
+  const [draft, setDraft] = useState("");
+  const [reactingTo, setReactingTo] = useState<number | null>(null);
+  const nextIdRef = useRef(100);
+  const pressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressFiredRef = useRef(false);
+
+  useEffect(() => {
+    return () => {
+      if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+    };
+  }, []);
+
+  const send = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const id = nextIdRef.current;
+    nextIdRef.current += 1;
+    setMessages((previous) => [...previous.slice(-7), { id, text: trimmed, sent: true }]);
+    setDraft("");
+  }, []);
+
+  const startPress = useCallback((id: number) => {
+    if (pressTimerRef.current) clearTimeout(pressTimerRef.current);
+    longPressFiredRef.current = false;
+    pressTimerRef.current = setTimeout(() => {
+      longPressFiredRef.current = true;
+      setReactingTo(id);
+    }, LONG_PRESS_MS);
+  }, []);
+
+  const cancelPress = useCallback(() => {
+    if (pressTimerRef.current) {
+      clearTimeout(pressTimerRef.current);
+      pressTimerRef.current = null;
+    }
+  }, []);
+
+  const react = useCallback((id: number, emoji: string) => {
+    setMessages((previous) =>
+      previous.map((message) =>
+        message.id === id
+          ? { ...message, reaction: message.reaction === emoji ? undefined : emoji }
+          : message,
+      ),
+    );
+    setReactingTo(null);
+  }, []);
+
+  const draftId = nextIdRef.current;
+
+  return (
+    <div
+      className="relative flex h-[620px] w-[340px] flex-col overflow-hidden rounded-[44px] bg-black shadow-2xl shadow-black/60 ring-8 ring-black select-none"
+      onClick={() => {
+        if (longPressFiredRef.current) {
+          longPressFiredRef.current = false;
+          return;
+        }
+        setReactingTo(null);
+      }}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b border-white/10 bg-[#0d0d0f]/90 px-4 pt-5 pb-3">
+        <ChevronLeft className="size-5 text-sky-400" />
+        <div className="grid size-9 place-items-center rounded-full bg-gradient-to-b from-[#f0a58f] to-[#c76b52] text-[13px] font-semibold text-white">
+          NV
+        </div>
+        <div className="flex-1">
+          <p className="text-[14px] font-semibold text-white">Nova</p>
+          <p className="text-[11px] text-white/40">iMessage</p>
+        </div>
+        <Video className="size-5 text-sky-400" />
+      </div>
+
+      {/* Thread */}
+      <div className="flex flex-1 flex-col justify-end gap-1.5 overflow-hidden px-4 pb-3">
+        {messages.map((message) => (
+          <motion.div
+            key={message.id}
+            layout="position"
+            className={`flex ${message.sent ? "justify-end" : "justify-start"}`}
+          >
+            <div className="relative max-w-[230px]">
+              <motion.div
+                layoutId={message.sent ? `bubble-${message.id}` : undefined}
+                transition={{ type: "spring", duration: 0.5, bounce: 0.25 }}
+                onPointerDown={() => startPress(message.id)}
+                onPointerUp={cancelPress}
+                onPointerLeave={cancelPress}
+                style={{ borderRadius: 18 }}
+                className={`px-3.5 py-2 text-[14px] leading-snug ${
+                  message.sent ? "bg-[#0a84ff] text-white" : "bg-[#26262a] text-white"
+                }`}
+              >
+                {message.text}
+              </motion.div>
+
+              {/* Tapback badge */}
+              <AnimatePresence>
+                {message.reaction && (
+                  <motion.span
+                    key={message.reaction}
+                    initial={{ scale: 0, y: 6 }}
+                    animate={{ scale: 1, y: 0 }}
+                    exit={{ scale: 0 }}
+                    transition={{ type: "spring", duration: 0.4, bounce: 0.55 }}
+                    className={`absolute -top-4 grid size-7 place-items-center rounded-full bg-[#3a3a3f] text-[13px] shadow-lg ring-2 ring-black ${
+                      message.sent ? "-left-3" : "-right-3"
+                    }`}
+                  >
+                    {message.reaction}
+                  </motion.span>
+                )}
+              </AnimatePresence>
+
+              {/* Tapback picker */}
+              <AnimatePresence>
+                {reactingTo === message.id && (
+                  <motion.div
+                    key="picker"
+                    initial={{ opacity: 0, scale: 0.4, y: 6 }}
+                    animate={{ opacity: 1, scale: 1, y: 0 }}
+                    exit={{ opacity: 0, scale: 0.4, y: 6 }}
+                    transition={{ type: "spring", duration: 0.38, bounce: 0.4 }}
+                    style={{ transformOrigin: message.sent ? "bottom right" : "bottom left" }}
+                    className={`absolute -top-11 z-20 flex gap-1 rounded-full bg-[#2c2c30] px-2.5 py-1.5 shadow-2xl ring-1 ring-white/10 ${
+                      message.sent ? "right-0" : "left-0"
+                    }`}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    {TAPBACKS.map((emoji) => (
+                      <motion.button
+                        type="button"
+                        key={emoji}
+                        whileHover={{ scale: 1.3, y: -2 }}
+                        whileTap={{ scale: 0.85 }}
+                        onClick={() => react(message.id, emoji)}
+                        className="text-[17px]"
+                      >
+                        {emoji}
+                      </motion.button>
+                    ))}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Suggestions */}
+      <div className="flex gap-2 px-4 pb-2">
+        {SUGGESTIONS.map((suggestion) => (
+          <button
+            type="button"
+            key={suggestion}
+            onClick={() => send(suggestion)}
+            className="rounded-full bg-white/[0.07] px-3 py-1.5 text-[12px] text-white/70 ring-1 ring-white/10 transition-colors hover:bg-white/[0.12] hover:text-white"
+          >
+            {suggestion}
+          </button>
+        ))}
+      </div>
+
+      {/* Composer */}
+      <div className="flex items-center gap-2 border-t border-white/10 bg-[#0d0d0f]/90 px-4 pt-2.5 pb-6">
+        <div className="relative flex h-9 flex-1 items-center rounded-full bg-[#1c1c20] px-4 ring-1 ring-white/10">
+          {draft ? (
+            <motion.span
+              key={draftId}
+              layoutId={`bubble-${draftId}`}
+              transition={{ type: "spring", duration: 0.5, bounce: 0.25 }}
+              style={{ borderRadius: 18 }}
+              className="pointer-events-none absolute inset-y-0 left-4 flex items-center text-[14px] text-white"
+            >
+              {draft}
+            </motion.span>
+          ) : null}
+          <input
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") send(draft);
+            }}
+            placeholder="iMessage"
+            className="w-full bg-transparent text-[14px] text-transparent caret-sky-400 outline-none placeholder:text-white/35"
+          />
+        </div>
+        <motion.button
+          type="button"
+          aria-label="Send"
+          onClick={() => send(draft)}
+          whileTap={{ scale: 0.85 }}
+          animate={{
+            backgroundColor: draft.trim() ? "#0a84ff" : "#26262a",
+            scale: draft.trim() ? 1 : 0.92,
+          }}
+          className="grid size-8 shrink-0 place-items-center rounded-full text-white"
+        >
+          <ArrowUp className="size-4" strokeWidth={3} />
+        </motion.button>
+      </div>
+    </div>
+  );
+};

--- a/content/imessage-send/meta.json
+++ b/content/imessage-send/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "iMessage Send",
+  "description": "The iMessage send morph — your draft genies from the composer into the thread, with long-press tapbacks.",
+  "tags": ["mobile", "effects", "forms"]
+}

--- a/content/imessage-send/package.json
+++ b/content/imessage-send/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/imessage-send",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/imessage-send/preview.tsx
+++ b/content/imessage-send/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ImessageSend } from "./imessage-send";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#1c1e26_0%,#0e0f14_55%,#050608_100%)] p-5">
+      <ImessageSend />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@uicapsule/gradient-orb':
         specifier: workspace:*
         version: link:../../content/gradient-orb
+      '@uicapsule/imessage-send':
+        specifier: workspace:*
+        version: link:../../content/imessage-send
       '@uicapsule/infinite-grid':
         specifier: workspace:*
         version: link:../../content/infinite-grid
@@ -610,6 +613,28 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/imessage-send:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/infinite-grid:
     dependencies:


### PR DESCRIPTION
iMessage thread capsule:

- Typed drafts genie-morph from the composer into the thread via shared `layoutId` (pre-allocated message id pairs the composer overlay with the incoming bubble)
- Long-press any bubble → tapback picker blooms; badge sticks w/ springy pop; re-pick toggles
- Suggestion chips for one-tap sends; send button inflates when a draft exists

Verified in-browser: chip send, typed send, tapback pick + badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an iMessage-style send morph with tapbacks. Typed drafts morph from the composer into the thread, with suggestion chips and long-press reactions.

- **New Features**
  - Composer-to-thread morph using shared `layoutId` and preallocated ids.
  - Long-press on any bubble opens a tapback picker; badges toggle with springy animation.
  - One-tap suggestion chips and Enter/click send; send button scales when a draft exists.

- **Dependencies**
  - Adds new workspace package `@uicapsule/imessage-send` and links it in `apps/web`.
  - Uses `motion` and `lucide-react`; lockfile updated.

<sup>Written for commit 6f83089e04f9e9e40453f98bc04863690b25ad17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

