### PR TITLE
feat: screenshot-capture — flash + corner thumbnail

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -41,6 +41,7 @@
     "@uicapsule/like-button": "workspace:*",
     "@uicapsule/particle-orb": "workspace:*",
     "@uicapsule/radial-slider": "workspace:*",
+    "@uicapsule/screenshot-capture": "workspace:*",
     "@uicapsule/sidebar": "workspace:*",
     "@uicapsule/snail-timer": "workspace:*",
     "@uicapsule/spinner-pixel-grid": "workspace:*",

--- a/content/screenshot-capture/meta.json
+++ b/content/screenshot-capture/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Screenshot Capture",
+  "description": "The iOS screenshot moment — flash, the screen shrinks into a corner thumbnail, lingers, then swipes away.",
+  "tags": ["mobile", "effects", "skeuomorphism"]
+}

--- a/content/screenshot-capture/package.json
+++ b/content/screenshot-capture/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/screenshot-capture",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/screenshot-capture/preview.tsx
+++ b/content/screenshot-capture/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ScreenshotCapture } from "./screenshot-capture";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#1b1d26_0%,#0d0e14_55%,#050609_100%)] p-5">
+      <ScreenshotCapture />
+    </main>
+  );
+};
+
+export default Preview;

--- a/content/screenshot-capture/screenshot-capture.tsx
+++ b/content/screenshot-capture/screenshot-capture.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type FC } from "react";
+import { Camera } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
+
+const LINGER_MS = 4500;
+
+// The "wallpaper" is pure CSS so the thumbnail can be an exact copy.
+const Scene: FC = () => (
+  <div className="absolute inset-0 overflow-hidden bg-[#0b1120]">
+    <div className="absolute inset-0 bg-[radial-gradient(circle_at_70%_18%,#fbbf24_0%,#f97316_18%,transparent_40%)]" />
+    <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_120%,#312e81_0%,transparent_60%)]" />
+    {/* Mountain silhouettes */}
+    <div
+      className="absolute bottom-0 left-[-30%] h-64 w-[90%] bg-[#1e2749]"
+      style={{ clipPath: "polygon(0 100%, 50% 0, 100% 100%)" }}
+    />
+    <div
+      className="absolute bottom-0 right-[-25%] h-52 w-[80%] bg-[#141b36]"
+      style={{ clipPath: "polygon(0 100%, 45% 8%, 100% 100%)" }}
+    />
+    <div className="absolute right-0 bottom-0 left-0 h-24 bg-gradient-to-t from-[#0b1120]/80 to-transparent" />
+    <p className="absolute top-12 left-6 text-[13px] font-medium text-white/60">Golden hour</p>
+    <p className="absolute top-[68px] left-6 text-[24px] font-semibold tracking-tight text-white">
+      Dolomites, Italy
+    </p>
+  </div>
+);
+
+type Shot = { id: number };
+
+export const ScreenshotCapture = () => {
+  const [flashKey, setFlashKey] = useState(0);
+  const [shot, setShot] = useState<Shot | null>(null);
+  const nextIdRef = useRef(1);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const capture = useCallback(() => {
+    const id = nextIdRef.current;
+    nextIdRef.current += 1;
+    setFlashKey(id);
+    setShot({ id });
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setShot(null), LINGER_MS);
+  }, []);
+
+  return (
+    <div className="relative h-[620px] w-[340px] overflow-hidden rounded-[44px] shadow-2xl shadow-black/60 ring-8 ring-black select-none">
+      <Scene />
+
+      {/* Flash */}
+      <AnimatePresence>
+        {flashKey > 0 && (
+          <motion.div
+            key={flashKey}
+            aria-hidden
+            initial={{ opacity: 0.95 }}
+            animate={{ opacity: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut" }}
+            className="pointer-events-none absolute inset-0 z-30 bg-white"
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Thumbnail: an exact CSS copy of the scene, shrinking into the corner */}
+      <AnimatePresence>
+        {shot && (
+          <motion.div
+            key={shot.id}
+            drag="x"
+            dragConstraints={{ left: 0, right: 0 }}
+            dragElastic={{ left: 0.9, right: 0.05 }}
+            onDragEnd={(_, info) => {
+              if (info.offset.x < -40) setShot(null);
+            }}
+            initial={{ scale: 1, x: 0, y: 0, borderRadius: 36 }}
+            animate={{ scale: 0.2, x: -119, y: 218, borderRadius: 12 }}
+            exit={{ x: -420, opacity: 0, transition: { duration: 0.25, ease: "easeIn" } }}
+            transition={{ type: "spring", duration: 0.65, bounce: 0.22, delay: 0.12 }}
+            className="absolute inset-0 z-20 cursor-grab overflow-hidden shadow-2xl shadow-black/80 ring-4 ring-white active:cursor-grabbing"
+          >
+            <Scene />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Capture control */}
+      <div className="absolute inset-x-0 bottom-6 z-10 flex justify-center">
+        <motion.button
+          type="button"
+          onClick={capture}
+          whileTap={{ scale: 0.92 }}
+          className="flex items-center gap-2 rounded-full bg-white/12 px-4 py-2.5 text-[13px] font-medium text-white backdrop-blur-xl ring-1 ring-white/20 transition-colors hover:bg-white/20"
+        >
+          <Camera className="size-4" />
+          Screenshot
+        </motion.button>
+      </div>
+
+      <p className="pointer-events-none absolute inset-x-0 bottom-[70px] z-10 text-center text-[11px] text-white/35">
+        Capture, then swipe the thumbnail away
+      </p>
+    </div>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@uicapsule/radial-slider':
         specifier: workspace:*
         version: link:../../content/radial-slider
+      '@uicapsule/screenshot-capture':
+        specifier: workspace:*
+        version: link:../../content/screenshot-capture
       '@uicapsule/sidebar':
         specifier: workspace:*
         version: link:../../content/sidebar
@@ -722,6 +725,28 @@ importers:
       '@number-flow/react':
         specifier: ^0.6.0
         version: 0.6.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+
+  content/screenshot-capture:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
The iOS screenshot moment:

- White flash, then the whole screen (a pure-CSS scene, so the 'thumbnail' is an exact copy) springs down into the bottom-left corner w/ white ring
- Lingers ~4.5s, auto-slides out — or swipe it left to dismiss early
- Repeatable; each capture re-arms the flash + timer

Verified in-browser: capture, thumbnail landing, swipe-dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@uicapsule/screenshot-capture`, an iOS-style screenshot interaction: white flash, then the screen shrinks into a bottom-left thumbnail that lingers and can be swiped away. Includes a preview at `./preview.tsx` and links the package to `apps/web`.

- **New Features**
  - `ScreenshotCapture` component with a pure‑CSS scene so the thumbnail is an exact copy.
  - Flash overlay and animated corner thumbnail with white ring; drag left to dismiss; auto-dismiss after 4.5s; repeated captures re‑arm.
  - Exported `./preview` for quick in-browser demo.

- **Dependencies**
  - Added `motion` and `lucide-react` to `@uicapsule/screenshot-capture`.
  - Added `@uicapsule/screenshot-capture` to `apps/web` workspace dependencies.

<sup>Written for commit d2c9cf17e3c2e3be08d593dfed27efab4488fb72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![screenshot-capture](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr37-screenshot-capture.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-screenshot-capture-kyh-io.vercel.app/preview-frame/screenshot-capture)._
