### PR TITLE
feat: chat-heads — floating bubble w/ edge snap + magnetic dismiss

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@uicapsule/background-shapes": "workspace:*",
     "@uicapsule/card-stack": "workspace:*",
     "@uicapsule/carousel-3d": "workspace:*",
+    "@uicapsule/chat-heads": "workspace:*",
     "@uicapsule/dynamic-ai-composer": "workspace:*",
     "@uicapsule/dynamic-island": "workspace:*",
     "@uicapsule/expanding-header-menu": "workspace:*",

--- a/content/chat-heads/chat-heads.tsx
+++ b/content/chat-heads/chat-heads.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { MessageCircle, X } from "lucide-react";
+import { AnimatePresence, motion, useAnimation } from "motion/react";
+
+const STAGE_WIDTH = 340;
+const STAGE_HEIGHT = 620;
+const HEAD = 62;
+const EDGE_PAD = 10;
+const DISMISS_X = STAGE_WIDTH / 2;
+const DISMISS_Y = STAGE_HEIGHT - 86;
+const MAGNET_RADIUS = 110;
+
+const FEED = [
+  ["Weekend plans 🏔️", "Riley: trailhead at 7?"],
+  ["design-crit", "Mia: shipping the tokens PR"],
+  ["Nova", "sent you 3 photos"],
+  ["lobby", "Sam: capsule 014 is wild"],
+];
+
+export const ChatHeads = () => {
+  const controls = useAnimation();
+  const positionRef = useRef({ x: STAGE_WIDTH - HEAD - EDGE_PAD, y: 120 });
+  const [dragging, setDragging] = useState(false);
+  const [nearDismiss, setNearDismiss] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [unread, setUnread] = useState(3);
+
+  const headCenter = (offsetX: number, offsetY: number) => ({
+    x: positionRef.current.x + offsetX + HEAD / 2,
+    y: positionRef.current.y + offsetY + HEAD / 2,
+  });
+
+  const settle = (offsetX: number, offsetY: number, velocityX: number, velocityY: number) => {
+    setDragging(false);
+    const center = headCenter(offsetX, offsetY);
+
+    if (Math.hypot(center.x - DISMISS_X, center.y - DISMISS_Y) < MAGNET_RADIUS) {
+      // Swallowed by the X.
+      positionRef.current = { x: DISMISS_X - HEAD / 2, y: DISMISS_Y - HEAD / 2 };
+      void controls
+        .start({
+          x: positionRef.current.x,
+          y: positionRef.current.y,
+          scale: 0.15,
+          opacity: 0,
+          transition: { type: "spring", duration: 0.35, bounce: 0 },
+        })
+        .then(() => setDismissed(true));
+      setNearDismiss(false);
+      return;
+    }
+
+    const projectedX = positionRef.current.x + offsetX + velocityX * 0.16;
+    const projectedY = positionRef.current.y + offsetY + velocityY * 0.16;
+    const snapX =
+      projectedX + HEAD / 2 < STAGE_WIDTH / 2 ? EDGE_PAD : STAGE_WIDTH - HEAD - EDGE_PAD;
+    const snapY = Math.min(STAGE_HEIGHT - HEAD - 120, Math.max(56, projectedY));
+    positionRef.current = { x: snapX, y: snapY };
+    void controls.start({
+      x: snapX,
+      y: snapY,
+      transition: { type: "spring", duration: 0.55, bounce: 0.35 },
+    });
+  };
+
+  const restore = () => {
+    setDismissed(false);
+    setUnread(3);
+    positionRef.current = { x: STAGE_WIDTH - HEAD - EDGE_PAD, y: 120 };
+    void controls.start({
+      x: positionRef.current.x,
+      y: positionRef.current.y,
+      scale: [0.3, 1],
+      opacity: 1,
+      transition: { type: "spring", duration: 0.5, bounce: 0.45 },
+    });
+  };
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-[44px] bg-[#0e0f14] shadow-2xl shadow-black/60 ring-8 ring-black select-none"
+      style={{ width: STAGE_WIDTH, height: STAGE_HEIGHT }}
+    >
+      {/* Backdrop: a chat list */}
+      <div className="px-5 pt-12">
+        <p className="text-[22px] font-bold text-white">Chats</p>
+        <div className="mt-3 space-y-1">
+          {FEED.map(([title, line]) => (
+            <div key={title} className="flex items-center gap-3 rounded-2xl p-2.5">
+              <div className="size-11 shrink-0 rounded-full bg-gradient-to-b from-[#3d4552] to-[#23272e]" />
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-semibold text-white/90">{title}</p>
+                <p className="truncate text-[12px] text-white/40">{line}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Dismiss target */}
+      <AnimatePresence>
+        {dragging && (
+          <motion.div
+            key="dismiss"
+            initial={{ opacity: 0, y: 30, scale: 0.6 }}
+            animate={{
+              opacity: 1,
+              y: 0,
+              scale: nearDismiss ? 1.35 : 1,
+            }}
+            exit={{ opacity: 0, y: 30, scale: 0.6 }}
+            transition={{ type: "spring", duration: 0.35, bounce: 0.3 }}
+            className="absolute z-20 grid size-14 place-items-center rounded-full bg-black/60 ring-2 ring-white/40 backdrop-blur-md"
+            style={{ left: DISMISS_X - 28, top: DISMISS_Y - 28 }}
+          >
+            <X className="size-6 text-white" />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Chat head */}
+      {!dismissed && (
+        <motion.div
+          drag
+          dragMomentum={false}
+          dragElastic={0.1}
+          initial={{ x: positionRef.current.x, y: positionRef.current.y }}
+          animate={controls}
+          onDragStart={() => {
+            setDragging(true);
+            setUnread(0);
+          }}
+          onDrag={(_, info) => {
+            const center = headCenter(info.offset.x, info.offset.y);
+            setNearDismiss(Math.hypot(center.x - DISMISS_X, center.y - DISMISS_Y) < MAGNET_RADIUS);
+          }}
+          onDragEnd={(_, info) =>
+            settle(info.offset.x, info.offset.y, info.velocity.x, info.velocity.y)
+          }
+          className="absolute top-0 left-0 z-30 cursor-grab active:cursor-grabbing"
+          style={{ width: HEAD, height: HEAD }}
+        >
+          <div className="relative size-full">
+            <div className="grid size-full place-items-center rounded-full bg-gradient-to-b from-[#f0a58f] to-[#c76b52] shadow-xl shadow-black/50 ring-2 ring-white/20">
+              <span className="text-[18px] font-semibold text-white">NV</span>
+            </div>
+            <AnimatePresence>
+              {unread > 0 && (
+                <motion.span
+                  key="badge"
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  exit={{ scale: 0 }}
+                  transition={{ type: "spring", duration: 0.35, bounce: 0.5 }}
+                  className="absolute -top-1 -right-1 grid size-5 place-items-center rounded-full bg-[#0a84ff] text-[11px] font-bold text-white ring-2 ring-[#0e0f14]"
+                >
+                  {unread}
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+      )}
+
+      {/* Restore */}
+      <AnimatePresence>
+        {dismissed && (
+          <motion.button
+            key="restore"
+            type="button"
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 12 }}
+            onClick={restore}
+            className="absolute bottom-16 left-1/2 z-20 flex -translate-x-1/2 items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-[12px] font-medium text-white ring-1 ring-white/15 backdrop-blur-md"
+          >
+            <MessageCircle className="size-4" /> Bring Nova back
+          </motion.button>
+        )}
+      </AnimatePresence>
+
+      <p className="pointer-events-none absolute inset-x-0 bottom-5 text-center text-[11px] text-white/30">
+        Flick the head · drag it to the X to dismiss
+      </p>
+    </div>
+  );
+};

--- a/content/chat-heads/meta.json
+++ b/content/chat-heads/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Chat Heads",
+  "description": "Messenger's floating chat head — flick it and it snaps to an edge; drag it to the magnetic X and it gets swallowed.",
+  "tags": ["mobile", "effects", "navigation"]
+}

--- a/content/chat-heads/package.json
+++ b/content/chat-heads/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/chat-heads",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/chat-heads/preview.tsx
+++ b/content/chat-heads/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ChatHeads } from "./chat-heads";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#1a1c23_0%,#0d0e13_55%,#050609_100%)] p-5">
+      <ChatHeads />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@uicapsule/carousel-3d':
         specifier: workspace:*
         version: link:../../content/carousel-3d
+      '@uicapsule/chat-heads':
+        specifier: workspace:*
+        version: link:../../content/chat-heads
       '@uicapsule/dynamic-ai-composer':
         specifier: workspace:*
         version: link:../../content/dynamic-ai-composer
@@ -392,6 +395,28 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/chat-heads:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/dynamic-ai-composer:
     dependencies:


### PR DESCRIPTION
Messenger's greatest hit:

- Flick the head: velocity projection picks the edge, springs in w/ overshoot; y clamped to safe area
- Dragging reveals the dismiss X; within the magnet radius it inflates; release → head swallowed (scale-to-zero into the X)
- Unread badge clears on first touch; restore pill brings Nova back w/ a bounce

Verified in-browser: edge snap, magnet grow, swallow, restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@uicapsule/chat-heads`, a floating chat head with velocity-based edge snap and a magnetic dismiss.

- New Features
  - Draggable head snaps to the nearest edge based on flick velocity; vertical position is clamped to a safe area.
  - Dismiss “X” appears while dragging; it grows within the magnetic radius; releasing inside shrinks/fades the head into the target.
  - Unread badge clears on first touch; “Bring Nova back” restores the head with a spring bounce.
  - New `content/chat-heads` package with a preview, wired into `apps/web`.

<sup>Written for commit 60af0b009fa72d006cb86e7ca1eeb5fee36ae9b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![chat-heads](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr42-chat-heads.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-chat-heads-kyh-io.vercel.app/preview-frame/chat-heads)._
