### PR TITLE
feat: overscroll-stretch — Android 12 stretch overscroll

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@uicapsule/ios-volume-slider": "workspace:*",
     "@uicapsule/light-dark-toggle": "workspace:*",
     "@uicapsule/like-button": "workspace:*",
+    "@uicapsule/overscroll-stretch": "workspace:*",
     "@uicapsule/particle-orb": "workspace:*",
     "@uicapsule/radial-slider": "workspace:*",
     "@uicapsule/sidebar": "workspace:*",

--- a/content/overscroll-stretch/meta.json
+++ b/content/overscroll-stretch/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Overscroll Stretch",
+  "description": "Android 12's overscroll — the list itself stretches at the boundary and springs back, no glow.",
+  "tags": ["mobile", "effects", "navigation"]
+}

--- a/content/overscroll-stretch/overscroll-stretch.tsx
+++ b/content/overscroll-stretch/overscroll-stretch.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Music2 } from "lucide-react";
+import { animate, motion, useMotionValue, useTransform } from "motion/react";
+
+const TRACKS = [
+  ["Night Drive", "Solenne", "3:42"],
+  ["Copper Sky", "Field Notes", "4:05"],
+  ["Detent", "Haptic Club", "2:58"],
+  ["Phosphor", "CRT Dreams", "3:21"],
+  ["Edge Peek", "Backstack", "3:47"],
+  ["Split Flap", "Terminal 5", "4:12"],
+  ["Gooey", "Surface Tension", "3:03"],
+  ["Rolodex", "Paper Trail", "2:47"],
+  ["Cold Air", "Vent", "3:58"],
+  ["Snap Point", "Sheet Music", "3:15"],
+  ["Blur In", "Crossfade", "4:22"],
+  ["Warm Rose", "HI/LO", "3:36"],
+];
+
+const MAX_STRETCH = 0.14;
+const RESISTANCE = 1400;
+
+export const OverscrollStretch = () => {
+  const overscroll = useMotionValue(0); // + = pulled past top, - = past bottom
+  const scaleY = useTransform(overscroll, (value) => 1 + Math.abs(value) * MAX_STRETCH);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [origin, setOrigin] = useState<"top" | "bottom">("top");
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyOverscroll = (deltaY: number) => {
+    const node = scrollRef.current;
+    if (!node) return false;
+    const atTop = node.scrollTop <= 0;
+    const atBottom = node.scrollTop + node.clientHeight >= node.scrollHeight - 1;
+
+    if (atTop && deltaY < 0) {
+      setOrigin("top");
+      overscroll.set(Math.min(1, overscroll.get() - deltaY / RESISTANCE));
+      return true;
+    }
+    if (atBottom && deltaY > 0) {
+      setOrigin("bottom");
+      overscroll.set(Math.max(-1, overscroll.get() - deltaY / RESISTANCE));
+      return true;
+    }
+    return false;
+  };
+
+  const scheduleSettle = () => {
+    if (settleTimer.current) clearTimeout(settleTimer.current);
+    settleTimer.current = setTimeout(() => {
+      void animate(overscroll, 0, { type: "spring", duration: 0.5, bounce: 0.3 });
+    }, 90);
+  };
+
+  return (
+    <div className="relative flex h-[600px] w-[360px] flex-col overflow-hidden rounded-[36px] bg-[#101014] shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none">
+      <div className="flex items-center justify-between px-5 pt-5 pb-3">
+        <p className="text-[20px] font-bold text-white">Library</p>
+        <span className="text-[11px] text-white/35">Android 12 overscroll</span>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto overscroll-contain px-3 pb-3 [scrollbar-width:none]"
+        onWheel={(event) => {
+          if (applyOverscroll(event.deltaY)) scheduleSettle();
+        }}
+      >
+        <motion.div
+          style={{
+            scaleY,
+            transformOrigin: origin === "top" ? "top center" : "bottom center",
+          }}
+          className="space-y-1"
+        >
+          {TRACKS.map(([title, artist, length], index) => (
+            <div
+              key={title}
+              className="flex items-center gap-3 rounded-xl px-2.5 py-2 transition-colors hover:bg-white/[0.05]"
+            >
+              <div
+                className="grid size-10 shrink-0 place-items-center rounded-lg"
+                style={{
+                  background: `linear-gradient(135deg, hsl(${(index * 47 + 200) % 360} 45% 38%), hsl(${(index * 47 + 250) % 360} 55% 22%))`,
+                }}
+              >
+                <Music2 className="size-4 text-white/80" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[13px] font-medium text-white">{title}</p>
+                <p className="truncate text-[11px] text-white/40">{artist}</p>
+              </div>
+              <span className="text-[11px] text-white/30 tabular-nums">{length}</span>
+            </div>
+          ))}
+        </motion.div>
+      </div>
+
+      <p className="pb-4 text-center text-[11px] text-white/30">
+        Scroll past either end — the list stretches, no glow
+      </p>
+    </div>
+  );
+};

--- a/content/overscroll-stretch/package.json
+++ b/content/overscroll-stretch/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@uicapsule/overscroll-stretch",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "lucide-react": "^1.16.0",
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/overscroll-stretch/preview.tsx
+++ b/content/overscroll-stretch/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { OverscrollStretch } from "./overscroll-stretch";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#1a1c22_0%,#0d0e12_55%,#050608_100%)] p-5">
+      <OverscrollStretch />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       '@uicapsule/like-button':
         specifier: workspace:*
         version: link:../../content/like-button
+      '@uicapsule/overscroll-stretch':
+        specifier: workspace:*
+        version: link:../../content/overscroll-stretch
       '@uicapsule/particle-orb':
         specifier: workspace:*
         version: link:../../content/particle-orb
@@ -694,6 +697,28 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
 
   content/line-chart: {}
+
+  content/overscroll-stretch:
+    dependencies:
+      lucide-react:
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/particle-orb:
     dependencies:


### PR DESCRIPTION
Music library list:

- Wheel past either boundary and the content itself stretches (scaleY from the near edge, resistance curve) — no glow
- Recoils w/ a bouncy spring after a short quiet period
- Track art is seeded HSL gradients; no assets

Verified in-browser: top stretch + settle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android 12–style overscroll stretching for lists: content stretches at the edges and springs back, replacing the glow. Introduces `@uicapsule/overscroll-stretch` with a preview and catalog metadata.

- New Features
  - Adds `OverscrollStretch` list that stretches at top/bottom with resistance and a spring recoil (no glow).
  - Uses `motion` scaleY transforms with edge-based transform origin and a short delayed settle.
  - Includes a preview component and `meta.json` under `content/overscroll-stretch/`.

- Dependencies
  - Adds `@uicapsule/overscroll-stretch` to `apps/web`.
  - Adds `motion` and `lucide-react` to the new package; updates `pnpm-lock.yaml`.

<sup>Written for commit eb196c0a963a1f1a0a5516f77f09c5ad2c07f92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![overscroll-stretch](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr44-overscroll-stretch.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-overscroll-stretch-kyh-io.vercel.app/preview-frame/overscroll-stretch)._
