### PR TITLE
feat: add ghost-text — inline completion ghost

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "@uicapsule/feed": "workspace:*",
     "@uicapsule/filter-bar": "workspace:*",
     "@uicapsule/geometric-orb": "workspace:*",
+    "@uicapsule/ghost-text": "workspace:*",
     "@uicapsule/gradient-orb": "workspace:*",
     "@uicapsule/infinite-grid": "workspace:*",
     "@uicapsule/ios-volume-slider": "workspace:*",

--- a/content/ghost-text/ghost-text.tsx
+++ b/content/ghost-text/ghost-text.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useEffect, useRef, useState, type FC } from "react";
+import { AnimatePresence, motion } from "motion/react";
+
+/**
+ * Ghost text — Cursor-style inline completion. Type on the active line;
+ * pause and a gray ghost continuation appears ahead of the caret. Tab
+ * absorbs it one word at a time (each word settles from ghost to solid),
+ * Esc waves it off, and typing through a matching character consumes it.
+ */
+
+const CONTEXT_LINES = [
+  "async function searchNotes(query: string) {",
+  "  const notes = await db.notes.list();",
+];
+
+/** Suggestion bank — matched against the active line's trailing content. */
+const SUGGESTIONS: { test: RegExp; text: string }[] = [
+  {
+    test: /return$/,
+    text: " notes.filter((note) => note.title.includes(query));",
+  },
+  {
+    test: /const\s+\w*$/,
+    text: "ranked = rankByRelevance(notes, query);",
+  },
+  {
+    test: /if\s*\($/,
+    text: "!query.trim()) return notes;",
+  },
+  {
+    test: /\.$/,
+    text: "toLowerCase().includes(query.toLowerCase());",
+  },
+];
+
+const DEFAULT_SUGGESTION = "return notes.filter((note) => note.title.includes(query));";
+
+const suggestFor = (line: string): string | null => {
+  if (line.endsWith(" ") && line.trim().length > 0) return null;
+  for (const s of SUGGESTIONS) {
+    if (s.test.test(line)) return s.text;
+  }
+  if (line.trim() === "") return `  ${DEFAULT_SUGGESTION}`;
+  return null;
+};
+
+const KEYWORD = /\b(async|function|const|await|return|if)\b/g;
+
+/** Minimal keyword tinting for the static context lines. */
+const Highlighted: FC<{ line: string }> = ({ line }) => {
+  const parts: { text: string; kw: boolean }[] = [];
+  let last = 0;
+  for (const match of line.matchAll(KEYWORD)) {
+    const index = match.index;
+    if (index > last) parts.push({ text: line.slice(last, index), kw: false });
+    parts.push({ text: match[0], kw: true });
+    last = index + match[0].length;
+  }
+  if (last < line.length) parts.push({ text: line.slice(last), kw: false });
+  return (
+    <>
+      {parts.map((part, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <span key={i} className={part.kw ? "text-[#c792ea]" : "text-[#c3cad6]"}>
+          {part.text}
+        </span>
+      ))}
+    </>
+  );
+};
+
+/** A chunk of ghost that was just accepted — settles from gray to solid. */
+type AcceptedChunk = { id: number; text: string };
+
+export const GhostText = () => {
+  const [typed, setTyped] = useState("  ");
+  const [accepted, setAccepted] = useState<AcceptedChunk[]>([]);
+  const [ghost, setGhost] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const chunkIdRef = useRef(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Synchronous mirrors — keydown events can arrive faster than re-renders,
+  // so all string math happens on refs and state is just the render mirror.
+  const lineRef = useRef("  ");
+  const ghostRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const putGhost = (value: string | null) => {
+    ghostRef.current = value;
+    setGhost(value);
+  };
+
+  // Debounced suggestion after a typing pause.
+  const scheduleSuggestion = () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      if (ghostRef.current === null) putGhost(suggestFor(lineRef.current));
+    }, 550);
+  };
+
+  useEffect(() => {
+    scheduleSuggestion();
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [typed, accepted]);
+
+  const handleKey = (event: React.KeyboardEvent) => {
+    if (event.key === "Tab") {
+      event.preventDefault();
+      const g = ghostRef.current;
+      if (!g) return;
+      const match = /^\s*\S+\s?/.exec(g);
+      const chunk = match ? match[0] : g;
+      lineRef.current += chunk;
+      chunkIdRef.current += 1;
+      const id = chunkIdRef.current;
+      setAccepted((current) => [...current, { id, text: chunk }]);
+      const rest = g.slice(chunk.length);
+      putGhost(rest.length > 0 ? rest : null);
+      return;
+    }
+    if (event.key === "Escape") {
+      putGhost(null);
+      return;
+    }
+    if (event.key === "Backspace") {
+      event.preventDefault();
+      lineRef.current = lineRef.current.slice(0, -1);
+      setTyped(lineRef.current);
+      setAccepted([]);
+      putGhost(null);
+      return;
+    }
+    if (event.key.length === 1 && !event.metaKey && !event.ctrlKey) {
+      event.preventDefault();
+      lineRef.current += event.key;
+      setTyped(lineRef.current);
+      setAccepted([]);
+      // Typing through the ghost consumes it; a mismatch dismisses it.
+      const g = ghostRef.current;
+      putGhost(g && g.startsWith(event.key) ? g.slice(1) || null : null);
+    }
+  };
+
+  return (
+    <div
+      className="w-[600px] cursor-text overflow-hidden rounded-2xl bg-[#0d1017] font-mono text-[13.5px] shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Chrome */}
+      <div className="flex items-center gap-2 border-b border-white/[0.06] px-4 py-3">
+        <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+        <span className="size-2.5 rounded-full bg-[#febc2e]" />
+        <span className="size-2.5 rounded-full bg-[#28c840]" />
+        <span className="ml-3 rounded-md bg-white/[0.06] px-2.5 py-1 font-sans text-[11px] text-white/60">
+          search.ts
+        </span>
+        <span className="ml-auto font-sans text-[10px] text-white/30">
+          pause to summon · Tab accepts a word · Esc dismisses
+        </span>
+      </div>
+
+      {/* Editor body */}
+      <div className="px-4 py-4 leading-[1.85]">
+        {CONTEXT_LINES.map((line, index) => (
+          <div key={line} className="flex">
+            <span className="w-8 shrink-0 text-right text-[11px] leading-[1.85] text-white/20 select-none">
+              {index + 1}
+            </span>
+            <span className="pl-4 whitespace-pre">
+              <Highlighted line={line} />
+            </span>
+          </div>
+        ))}
+
+        {/* Active line */}
+        <div className="flex">
+          <span className="w-8 shrink-0 text-right text-[11px] leading-[1.85] text-white/20 select-none">
+            {CONTEXT_LINES.length + 1}
+          </span>
+          <span className="relative pl-4 whitespace-pre">
+            <span className="text-[#c3cad6]">{typed}</span>
+            {accepted.map((chunk) => (
+              <motion.span
+                key={chunk.id}
+                initial={{ color: "rgba(148,158,178,0.5)", y: 1 }}
+                animate={{ color: "rgba(195,202,214,1)", y: 0 }}
+                transition={{ duration: 0.3 }}
+                className="inline-block whitespace-pre"
+              >
+                {chunk.text}
+              </motion.span>
+            ))}
+            {/* Caret */}
+            <motion.span
+              aria-hidden
+              animate={{ opacity: [1, 1, 0, 0] }}
+              transition={{ duration: 1, repeat: Infinity, times: [0, 0.5, 0.5, 1] }}
+              className="relative -top-px inline-block h-[1.1em] w-[2px] translate-y-[3px] rounded-sm bg-[#7aa2ff] align-middle"
+            />
+            {/* Ghost */}
+            <AnimatePresence>
+              {ghost && (
+                <motion.span
+                  key={ghost.length === 0 ? "empty" : "ghost"}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0, transition: { duration: 0.12 } }}
+                  transition={{ duration: 0.25 }}
+                  className="whitespace-pre text-[#5a6376] italic"
+                >
+                  {ghost}
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </span>
+        </div>
+
+        <div className="flex">
+          <span className="w-8 shrink-0 text-right text-[11px] leading-[1.85] text-white/20 select-none">
+            {CONTEXT_LINES.length + 2}
+          </span>
+          <span className="pl-4 text-[#c3cad6]">{"}"}</span>
+        </div>
+      </div>
+
+      {/* Hidden input drives the keyboard */}
+      <input
+        ref={inputRef}
+        onKeyDown={handleKey}
+        className="absolute h-0 w-0 opacity-0"
+        aria-label="Code input"
+      />
+
+      {/* Status bar */}
+      <div className="flex items-center justify-between border-t border-white/[0.06] px-4 py-2 font-sans text-[10px] text-white/30">
+        <span>TypeScript</span>
+        <AnimatePresence mode="wait">
+          <motion.span
+            key={ghost ? "on" : "off"}
+            initial={{ opacity: 0, y: 3 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -3 }}
+            className={ghost ? "text-[#7aa2ff]" : ""}
+          >
+            {ghost ? "✦ suggestion ready" : "✦ idle"}
+          </motion.span>
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+};

--- a/content/ghost-text/ghost-text.tsx
+++ b/content/ghost-text/ghost-text.tsx
@@ -108,7 +108,6 @@ export const GhostText = () => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [typed, accepted]);
 
   const handleKey = (event: React.KeyboardEvent) => {

--- a/content/ghost-text/meta.json
+++ b/content/ghost-text/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Ghost Text",
+  "description": "Cursor-style inline completion — pause and a gray ghost appears ahead of the caret; Tab absorbs it word-by-word, typing through it consumes it.",
+  "tags": ["ai", "inputs"]
+}

--- a/content/ghost-text/package.json
+++ b/content/ghost-text/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uicapsule/ghost-text",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/ghost-text/preview.tsx
+++ b/content/ghost-text/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { GhostText } from "./ghost-text";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#171921_0%,#0b0d13_55%,#040508_100%)] p-5">
+      <GhostText />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@uicapsule/geometric-orb':
         specifier: workspace:*
         version: link:../../content/geometric-orb
+      '@uicapsule/ghost-text':
+        specifier: workspace:*
+        version: link:../../content/ghost-text
       '@uicapsule/gradient-orb':
         specifier: workspace:*
         version: link:../../content/gradient-orb
@@ -582,6 +585,25 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/ghost-text:
+    dependencies:
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/gradient-orb:
     dependencies:


### PR DESCRIPTION
Cursor-style inline completion in a minimal editor: pause typing and a gray italic ghost appears ahead of the caret (contextual suggestion bank keyed off the active line). Tab absorbs one word at a time — each accepted word animates from ghost gray to solid. Typing through a matching character consumes the ghost; a mismatch or Esc dismisses it. All keystroke math happens on refs so rapid input never reads stale state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@uicapsule/ghost-text`, a cursor‑style inline completion demo that shows a gray ghost ahead of the caret. Also drops an unused eslint-disable in the new component.

- **New Features**
  - Inline suggestions after a 550ms pause from a regex-based bank.
  - Tab accepts one word at a time with gray→solid animation; typing consumes matches; Esc/Backspace clears.
  - Ref-driven key handling to avoid stale state on rapid input; includes a preview component.

- **Dependencies**
  - New workspace package `@uicapsule/ghost-text` and `motion@^12.40.0`; linked in `apps/web` with lockfile updates.

<sup>Written for commit 970c869147f4fe8111fdc2a0a15d9705b7d8130c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![ghost-text](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr53-ghost-text.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-ghost-text-kyh-io.vercel.app/preview-frame/ghost-text)._
