### PR TITLE
feat: add transcript-settle — live dictation settle

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "@uicapsule/spreadsheet": "workspace:*",
     "@uicapsule/tesla-climate": "workspace:*",
     "@uicapsule/tooltip-grid": "workspace:*",
+    "@uicapsule/transcript-settle": "workspace:*",
     "@uicapsule/voice-dictator": "workspace:*",
     "@uicapsule/wireframe-orb": "workspace:*",
     "@vercel/analytics": "^2.0.1",

--- a/content/transcript-settle/meta.json
+++ b/content/transcript-settle/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Transcript Settle",
+  "description": "Live dictation — interim words shimmer and wobble while the recognizer rewrites them, then each phrase settles solid. \"sent the dek\" becomes \"send the deck\".",
+  "tags": ["ai", "feedback"]
+}

--- a/content/transcript-settle/package.json
+++ b/content/transcript-settle/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uicapsule/transcript-settle",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/transcript-settle/preview.tsx
+++ b/content/transcript-settle/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { TranscriptSettle } from "./transcript-settle";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#171921_0%,#0b0d13_55%,#040508_100%)] p-5">
+      <TranscriptSettle />
+    </main>
+  );
+};
+
+export default Preview;

--- a/content/transcript-settle/transcript-settle.tsx
+++ b/content/transcript-settle/transcript-settle.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useRef, useState, type FC } from "react";
+import { motion } from "motion/react";
+
+/**
+ * Transcript settle — live dictation. Interim words arrive shimmering and
+ * unsure (the recognizer keeps rewriting them), then each phrase commits:
+ * words snap solid with a tiny settle. Watch "sent the dek" become
+ * "send the deck".
+ */
+
+type Segment = {
+  /** Interim hypotheses, in arrival order — the last one is what commits. */
+  steps: string[][];
+};
+
+const SCRIPT: Segment[] = [
+  {
+    steps: [
+      ["Remind"],
+      ["Remind", "me", "too"],
+      ["Remind", "me", "to", "sent", "the"],
+      ["Remind", "me", "to", "send", "the", "deck"],
+    ],
+  },
+  {
+    steps: [
+      ["to", "pria"],
+      ["to", "pria", "before", "the"],
+      ["to", "Priya", "before", "the", "standup"],
+    ],
+  },
+  {
+    steps: [
+      ["tomorrow"],
+      ["tomorrow", "—", "actually,"],
+      ["tomorrow", "—", "actually,", "make", "that"],
+      ["tomorrow", "—", "actually,", "make", "that", "Thursday."],
+    ],
+  },
+];
+
+const INTERIM_MS = 340;
+const COMMIT_PAUSE_MS = 420;
+const RESTART_PAUSE_MS = 2600;
+
+type Committed = { id: string; text: string };
+
+/** An unconfirmed word — shimmers and wobbles until the recognizer commits. */
+const InterimWord: FC<{ text: string; index: number }> = ({ text, index }) => (
+  <motion.span
+    initial={{ opacity: 0, y: 4, filter: "blur(3px)" }}
+    animate={{
+      opacity: [0.45, 0.75, 0.45],
+      y: [0.5, -0.5, 0.5],
+      filter: "blur(0.4px)",
+    }}
+    transition={{
+      opacity: { duration: 1.3, repeat: Infinity, ease: "easeInOut", delay: index * 0.13 },
+      y: { duration: 1.3, repeat: Infinity, ease: "easeInOut", delay: index * 0.13 },
+      filter: { duration: 0.2 },
+    }}
+    className="mr-[0.32em] inline-block text-white/70 italic"
+  >
+    {text}
+  </motion.span>
+);
+
+/** A confirmed word — lands with a small vertical settle and goes solid. */
+const SettledWord: FC<{ text: string }> = ({ text }) => (
+  <motion.span
+    initial={{ opacity: 0.55, y: -2.5, filter: "blur(1.5px)" }}
+    animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+    transition={{ type: "spring", stiffness: 500, damping: 30 }}
+    className="mr-[0.32em] inline-block text-white"
+  >
+    {text}
+  </motion.span>
+);
+
+export const TranscriptSettle = () => {
+  const [committed, setCommitted] = useState<Committed[]>([]);
+  const [interim, setInterim] = useState<string[]>([]);
+  const [listening, setListening] = useState(true);
+  const timersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const play = () => {
+    timersRef.current.forEach(clearTimeout);
+    timersRef.current = [];
+    setCommitted([]);
+    setInterim([]);
+    setListening(true);
+
+    let at = 600;
+    const schedule = (fn: () => void, delay: number) => {
+      timersRef.current.push(setTimeout(fn, delay));
+    };
+
+    SCRIPT.forEach((segment, segmentIndex) => {
+      segment.steps.forEach((step) => {
+        schedule(() => setInterim(step), at);
+        at += INTERIM_MS;
+      });
+      const final = segment.steps[segment.steps.length - 1] ?? [];
+      schedule(() => {
+        setInterim([]);
+        setCommitted((current) => [
+          ...current,
+          ...final.map((word, wordIndex) => ({
+            id: `${String(segmentIndex)}-${String(wordIndex)}`,
+            text: word,
+          })),
+        ]);
+      }, at);
+      at += COMMIT_PAUSE_MS;
+    });
+
+    schedule(() => setListening(false), at + 200);
+    schedule(play, at + RESTART_PAUSE_MS);
+  };
+
+  useEffect(() => {
+    play();
+    return () => timersRef.current.forEach(clearTimeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="w-[520px] overflow-hidden rounded-3xl bg-[#101116] shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none">
+      {/* Transcript */}
+      <div className="min-h-[190px] px-7 pt-7 pb-4 text-[17px] leading-[1.9] font-medium tracking-[-0.01em]">
+        {committed.map((word) => (
+          <SettledWord key={word.id} text={word.text} />
+        ))}
+        {interim.map((word, index) => (
+          <InterimWord key={`${String(index)}-${word}`} text={word} index={index} />
+        ))}
+        {listening && interim.length === 0 && committed.length === 0 && (
+          <span className="text-white/30">Listening…</span>
+        )}
+      </div>
+
+      {/* Mic bar */}
+      <div className="flex items-center gap-3 border-t border-white/[0.06] bg-white/[0.02] px-6 py-4">
+        <div className="relative flex size-9 items-center justify-center rounded-full bg-[#e5484d]">
+          {listening && (
+            <motion.span
+              aria-hidden
+              animate={{ scale: [1, 1.65], opacity: [0.45, 0] }}
+              transition={{ duration: 1.4, repeat: Infinity, ease: "easeOut" }}
+              className="absolute inset-0 rounded-full bg-[#e5484d]"
+            />
+          )}
+          <svg viewBox="0 0 24 24" className="relative size-4 fill-white">
+            <path d="M12 14a3 3 0 0 0 3-3V6a3 3 0 1 0-6 0v5a3 3 0 0 0 3 3Zm5-3a5 5 0 0 1-10 0H5a7 7 0 0 0 6 6.92V21h2v-3.08A7 7 0 0 0 19 11h-2Z" />
+          </svg>
+        </div>
+
+        {/* Level bars */}
+        <div className="flex h-8 flex-1 items-center gap-[3px]">
+          {Array.from({ length: 32 }, (_, index) => (
+            <motion.span
+              key={index}
+              animate={
+                listening
+                  ? { scaleY: [0.25, 0.4 + ((index * 37) % 23) / 26, 0.25] }
+                  : { scaleY: 0.18 }
+              }
+              transition={
+                listening
+                  ? {
+                      duration: 0.7 + ((index * 13) % 9) / 10,
+                      repeat: Infinity,
+                      ease: "easeInOut",
+                    }
+                  : { duration: 0.3 }
+              }
+              className="h-full flex-1 origin-center rounded-full bg-white/25"
+            />
+          ))}
+        </div>
+
+        <span
+          className={`text-[11px] font-medium tracking-wide uppercase ${
+            listening ? "text-[#e5484d]" : "text-white/35"
+          }`}
+        >
+          {listening ? "Rec" : "Done"}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       '@uicapsule/tooltip-grid':
         specifier: workspace:*
         version: link:../../content/tooltip-grid
+      '@uicapsule/transcript-settle':
+        specifier: workspace:*
+        version: link:../../content/transcript-settle
       '@uicapsule/voice-dictator':
         specifier: workspace:*
         version: link:../../content/voice-dictator
@@ -860,6 +863,25 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.19
         version: 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
+
+  content/transcript-settle:
+    dependencies:
       motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)


### PR DESCRIPTION
Live dictation: interim hypotheses arrive as shimmering italic words the recognizer keeps rewriting — "sent the" becomes "send the deck", "pria" becomes "Priya" — then each phrase commits and settles solid with a small spring. Pulsing mic ring, 32 seeded level bars that flatten when recording ends, script auto-loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new live dictation demo that shows interim words shimmer and final phrases spring-settle into place. Includes a pulsing mic ring, seeded level bars, and an auto-looping script.

- **New Features**
  - New `@uicapsule/transcript-settle` package with a TranscriptSettle component and preview.
  - Interim hypotheses wobble; committed words settle with a spring.
  - Mic ring pulses during “Rec”; 32 level bars animate and flatten when done.
  - Content metadata added for gallery; wired into web via `apps/web` dependency.

- **Dependencies**
  - Added `motion@^12.40.0`; lockfile updated.

<sup>Written for commit ae812f2badb8e2aef4daf4e9bdc9ab44cc0c70bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![transcript-settle](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr55-transcript-settle.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-transcript-settle-kyh-io.vercel.app/preview-frame/transcript-settle)._
