### PR TITLE
feat: add citation-beams — provenance beams

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,6 +28,7 @@
     "@uicapsule/background-shapes": "workspace:*",
     "@uicapsule/card-stack": "workspace:*",
     "@uicapsule/carousel-3d": "workspace:*",
+    "@uicapsule/citation-beams": "workspace:*",
     "@uicapsule/dynamic-ai-composer": "workspace:*",
     "@uicapsule/dynamic-island": "workspace:*",
     "@uicapsule/expanding-header-menu": "workspace:*",

--- a/content/citation-beams/citation-beams.tsx
+++ b/content/citation-beams/citation-beams.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useRef, useState, type FC, type ReactNode } from "react";
+import { AnimatePresence, motion } from "motion/react";
+
+/**
+ * Citation beams — hover a citation marker and a beam draws across to the
+ * source card, which lifts while the exact supporting passage sweeps
+ * highlighted. Provenance you can see.
+ */
+
+type Source = {
+  id: number;
+  title: string;
+  domain: string;
+  /** snippet parts: [before, passage, after] — the middle highlights */
+  snippet: [string, string, string];
+};
+
+const SOURCES: Source[] = [
+  {
+    id: 1,
+    title: "Sleep spindles and memory consolidation",
+    domain: "nature.com",
+    snippet: [
+      "During stage-2 sleep, ",
+      "spindle density predicted next-day recall accuracy",
+      " across all 44 participants.",
+    ],
+  },
+  {
+    id: 2,
+    title: "The cost of the all-nighter",
+    domain: "sleepjournal.org",
+    snippet: [
+      "One night of total deprivation ",
+      "reduced hippocampal encoding capacity by roughly 40%",
+      ", persisting after caffeine.",
+    ],
+  },
+  {
+    id: 3,
+    title: "Naps as micro-consolidation",
+    domain: "med.stanford.edu",
+    snippet: [
+      "A 26-minute nap ",
+      "restored declarative memory performance to baseline",
+      " in the afternoon cohort.",
+    ],
+  },
+];
+
+const BEAM_COLOR = "#7dd3fc";
+
+export const CitationBeams = () => {
+  const [active, setActive] = useState<number | null>(null);
+  const [beam, setBeam] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cardRefs = useRef(new Map<number, HTMLDivElement>());
+
+  const activate = (id: number, marker: HTMLElement) => {
+    const container = containerRef.current;
+    const card = cardRefs.current.get(id);
+    if (!container || !card) return;
+    const c = container.getBoundingClientRect();
+    const m = marker.getBoundingClientRect();
+    const t = card.getBoundingClientRect();
+    setActive(id);
+    setBeam({
+      x1: m.right - c.left + 2,
+      y1: m.top - c.top + m.height / 2,
+      x2: t.left - c.left - 2,
+      y2: t.top - c.top + t.height / 2,
+    });
+  };
+
+  const clear = () => {
+    setActive(null);
+    setBeam(null);
+  };
+
+  const Cite: FC<{ id: number; children?: ReactNode }> = ({ id }) => (
+    <button
+      type="button"
+      onMouseEnter={(event) => activate(id, event.currentTarget)}
+      onMouseLeave={clear}
+      onFocus={(event) => activate(id, event.currentTarget)}
+      onBlur={clear}
+      className={`mx-0.5 inline-flex size-[18px] -translate-y-[2px] items-center justify-center rounded-md text-[10px] font-bold transition-colors ${
+        active === id
+          ? "bg-[#7dd3fc] text-black"
+          : "bg-white/[0.08] text-[#7dd3fc] hover:bg-white/[0.14]"
+      }`}
+    >
+      {id}
+    </button>
+  );
+
+  const path = beam
+    ? `M ${String(beam.x1)} ${String(beam.y1)} C ${String(beam.x1 + 70)} ${String(beam.y1)}, ${String(beam.x2 - 70)} ${String(beam.y2)}, ${String(beam.x2)} ${String(beam.y2)}`
+    : "";
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex w-[720px] gap-6 rounded-3xl bg-[#101116] p-7 shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none"
+    >
+      {/* Answer pane */}
+      <div className="w-[340px] shrink-0">
+        <p className="mb-3 text-[11px] font-semibold tracking-[0.2em] text-white/35 uppercase">
+          Answer · 3 sources
+        </p>
+        <p className="text-[14.5px] leading-[1.95] text-white/80">
+          Sleep is when memory does its filing. Spindle activity during light sleep tracks how well
+          you'll recall new material tomorrow
+          <Cite id={1} />; skip a night entirely and the hippocampus encodes roughly 40% less
+          <Cite id={2} />. Even a half-hour nap claws a surprising amount of that capacity back
+          <Cite id={3} />.
+        </p>
+      </div>
+
+      {/* Sources pane */}
+      <div className="flex flex-1 flex-col justify-center gap-3">
+        {SOURCES.map((source) => (
+          <motion.div
+            key={source.id}
+            ref={(el) => {
+              if (el) cardRefs.current.set(source.id, el);
+              else cardRefs.current.delete(source.id);
+            }}
+            animate={{
+              scale: active === source.id ? 1.03 : 1,
+              x: active === source.id ? -4 : 0,
+            }}
+            transition={{ type: "spring", stiffness: 400, damping: 28 }}
+            className={`rounded-xl p-3.5 ring-1 transition-shadow ${
+              active === source.id
+                ? "bg-[#171b26] shadow-lg shadow-[#7dd3fc]/10 ring-[#7dd3fc]/45"
+                : "bg-white/[0.03] ring-white/[0.07]"
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={`flex size-[16px] items-center justify-center rounded text-[9px] font-bold ${
+                  active === source.id ? "bg-[#7dd3fc] text-black" : "bg-white/[0.08] text-white/50"
+                }`}
+              >
+                {source.id}
+              </span>
+              <p className="truncate text-[12px] font-semibold text-white/85">{source.title}</p>
+            </div>
+            <p className="mt-0.5 text-[10px] text-white/35">{source.domain}</p>
+            <p className="mt-1.5 text-[11.5px] leading-[1.65] text-white/55">
+              {source.snippet[0]}
+              <span className="relative inline">
+                <AnimatePresence>
+                  {active === source.id && (
+                    <motion.span
+                      initial={{ scaleX: 0 }}
+                      animate={{ scaleX: 1 }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.35, ease: "easeOut" }}
+                      className="absolute inset-x-0 -inset-y-0.5 origin-left rounded-[3px] bg-[#7dd3fc]/18"
+                    />
+                  )}
+                </AnimatePresence>
+                <span
+                  className={`relative transition-colors duration-200 ${
+                    active === source.id ? "text-[#bfe7ff]" : ""
+                  }`}
+                >
+                  {source.snippet[1]}
+                </span>
+              </span>
+              {source.snippet[2]}
+            </p>
+          </motion.div>
+        ))}
+      </div>
+
+      {/* Beam overlay */}
+      <svg className="pointer-events-none absolute inset-0 z-10 size-full">
+        <defs>
+          <linearGradient id="beam-gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor={BEAM_COLOR} stopOpacity="0.15" />
+            <stop offset="55%" stopColor={BEAM_COLOR} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={BEAM_COLOR} stopOpacity="0.5" />
+          </linearGradient>
+        </defs>
+        <AnimatePresence>
+          {beam && (
+            <motion.path
+              key={`${String(beam.x1)}-${String(beam.y2)}`}
+              d={path}
+              fill="none"
+              stroke="url(#beam-gradient)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              initial={{ pathLength: 0, opacity: 0.9 }}
+              animate={{ pathLength: 1, opacity: 1 }}
+              exit={{ opacity: 0, transition: { duration: 0.15 } }}
+              transition={{ duration: 0.4, ease: "easeOut" }}
+              style={{ filter: `drop-shadow(0 0 6px ${BEAM_COLOR}66)` }}
+            />
+          )}
+        </AnimatePresence>
+      </svg>
+    </div>
+  );
+};

--- a/content/citation-beams/citation-beams.tsx
+++ b/content/citation-beams/citation-beams.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type FC, type ReactNode } from "react";
+import { useRef, useState, type FC } from "react";
 import { AnimatePresence, motion } from "motion/react";
 
 /**
@@ -52,6 +52,26 @@ const SOURCES: Source[] = [
 
 const BEAM_COLOR = "#7dd3fc";
 
+const Cite: FC<{
+  id: number;
+  active: boolean;
+  onActivate: (id: number, marker: HTMLElement) => void;
+  onClear: () => void;
+}> = ({ id, active, onActivate, onClear }) => (
+  <button
+    type="button"
+    onMouseEnter={(event) => onActivate(id, event.currentTarget)}
+    onMouseLeave={onClear}
+    onFocus={(event) => onActivate(id, event.currentTarget)}
+    onBlur={onClear}
+    className={`mx-0.5 inline-flex size-[18px] -translate-y-[2px] items-center justify-center rounded-md text-[10px] font-bold transition-colors ${
+      active ? "bg-[#7dd3fc] text-black" : "bg-white/[0.08] text-[#7dd3fc] hover:bg-white/[0.14]"
+    }`}
+  >
+    {id}
+  </button>
+);
+
 export const CitationBeams = () => {
   const [active, setActive] = useState<number | null>(null);
   const [beam, setBeam] = useState<{ x1: number; y1: number; x2: number; y2: number } | null>(null);
@@ -79,23 +99,6 @@ export const CitationBeams = () => {
     setBeam(null);
   };
 
-  const Cite: FC<{ id: number; children?: ReactNode }> = ({ id }) => (
-    <button
-      type="button"
-      onMouseEnter={(event) => activate(id, event.currentTarget)}
-      onMouseLeave={clear}
-      onFocus={(event) => activate(id, event.currentTarget)}
-      onBlur={clear}
-      className={`mx-0.5 inline-flex size-[18px] -translate-y-[2px] items-center justify-center rounded-md text-[10px] font-bold transition-colors ${
-        active === id
-          ? "bg-[#7dd3fc] text-black"
-          : "bg-white/[0.08] text-[#7dd3fc] hover:bg-white/[0.14]"
-      }`}
-    >
-      {id}
-    </button>
-  );
-
   const path = beam
     ? `M ${String(beam.x1)} ${String(beam.y1)} C ${String(beam.x1 + 70)} ${String(beam.y1)}, ${String(beam.x2 - 70)} ${String(beam.y2)}, ${String(beam.x2)} ${String(beam.y2)}`
     : "";
@@ -113,9 +116,11 @@ export const CitationBeams = () => {
         <p className="text-[14.5px] leading-[1.95] text-white/80">
           Sleep is when memory does its filing. Spindle activity during light sleep tracks how well
           you'll recall new material tomorrow
-          <Cite id={1} />; skip a night entirely and the hippocampus encodes roughly 40% less
-          <Cite id={2} />. Even a half-hour nap claws a surprising amount of that capacity back
-          <Cite id={3} />.
+          <Cite id={1} active={active === 1} onActivate={activate} onClear={clear} />; skip a night
+          entirely and the hippocampus encodes roughly 40% less
+          <Cite id={2} active={active === 2} onActivate={activate} onClear={clear} />. Even a
+          half-hour nap claws a surprising amount of that capacity back
+          <Cite id={3} active={active === 3} onActivate={activate} onClear={clear} />.
         </p>
       </div>
 

--- a/content/citation-beams/meta.json
+++ b/content/citation-beams/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Citation Beams",
+  "description": "Provenance you can see — hover a citation and a beam draws across to the source card while the exact supporting passage sweeps highlighted.",
+  "tags": ["ai", "effects"]
+}

--- a/content/citation-beams/package.json
+++ b/content/citation-beams/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uicapsule/citation-beams",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/citation-beams/preview.tsx
+++ b/content/citation-beams/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { CitationBeams } from "./citation-beams";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#171921_0%,#0b0d13_55%,#040508_100%)] p-5">
+      <CitationBeams />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@uicapsule/carousel-3d':
         specifier: workspace:*
         version: link:../../content/carousel-3d
+      '@uicapsule/citation-beams':
+        specifier: workspace:*
+        version: link:../../content/citation-beams
       '@uicapsule/dynamic-ai-composer':
         specifier: workspace:*
         version: link:../../content/dynamic-ai-composer
@@ -392,6 +395,25 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/citation-beams:
+    dependencies:
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/dynamic-ai-composer:
     dependencies:


### PR DESCRIPTION
Hover a citation marker in the answer and a gradient SVG beam draws (pathLength tween with glow) across to the matching source card. The card lifts with a cyan ring while the exact supporting passage sweeps highlighted inside the snippet — provenance you can see. Keyboard focus triggers the same beam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Citation Beams: hovering or focusing a citation marker draws an animated SVG beam to the matching source card, which lifts and highlights the exact supporting passage. Improves provenance clarity in answers.

- **New Features**
  - Animated SVG beam links citation markers to source cards.
  - Card lift with cyan ring and sweeping highlight on the cited passage.
  - Works on hover and keyboard focus.

- **Dependencies**
  - Added `@uicapsule/citation-beams` workspace package with `motion`.
  - Linked `@uicapsule/citation-beams` in `apps/web/package.json`.
  - Updated lockfile.

<sup>Written for commit 741501ff6718f70b37a6aba6843eb65b7c28e32d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![citation-beams](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr61-citation-beams.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-citation-beams-kyh-io.vercel.app/preview-frame/citation-beams)._
