### PR TITLE
feat: add assistant-orb — four motion signatures

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@trpc/server": "catalog:",
     "@trpc/tanstack-react-query": "catalog:",
     "@uicapsule/ascii-renderer": "workspace:*",
+    "@uicapsule/assistant-orb": "workspace:*",
     "@uicapsule/background-pixel-stars": "workspace:*",
     "@uicapsule/background-shapes": "workspace:*",
     "@uicapsule/card-stack": "workspace:*",

--- a/content/assistant-orb/assistant-orb.tsx
+++ b/content/assistant-orb/assistant-orb.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+
+/**
+ * Assistant orb — one orb, four moods. Each state has a distinct motion
+ * signature: idle breathes, listening leans in and ripples, thinking
+ * swirls inward, speaking pulses in bursts. The signatures matter more
+ * than the gradients — you should be able to read the state from motion
+ * alone.
+ */
+
+type OrbState = "idle" | "listening" | "thinking" | "speaking";
+
+const STATES: { key: OrbState; label: string; blurb: string }[] = [
+  { key: "idle", label: "Idle", blurb: "slow breath, drifting color" },
+  { key: "listening", label: "Listening", blurb: "leans in, ripples outward" },
+  { key: "thinking", label: "Thinking", blurb: "contracts, swirls inward" },
+  { key: "speaking", label: "Speaking", blurb: "pulses with the voice" },
+];
+
+const ORB_VARIANTS = {
+  idle: {
+    scale: [1, 1.045, 1],
+    transition: { duration: 4.2, repeat: Infinity, ease: "easeInOut" as const },
+  },
+  listening: {
+    scale: [1.12, 1.16, 1.12],
+    transition: { duration: 1.1, repeat: Infinity, ease: "easeInOut" as const },
+  },
+  thinking: {
+    scale: [0.9, 0.93, 0.9],
+    transition: { duration: 1.8, repeat: Infinity, ease: "easeInOut" as const },
+  },
+  speaking: {
+    scale: [1, 1.09, 1.02, 1.11, 1.04, 1],
+    transition: { duration: 1.15, repeat: Infinity, ease: "easeInOut" as const },
+  },
+};
+
+/** Swirl layer speed per state — thinking spins hardest. */
+const SWIRL_DURATION: Record<OrbState, number> = {
+  idle: 14,
+  listening: 9,
+  thinking: 2.4,
+  speaking: 6,
+};
+
+const GLOW: Record<OrbState, string> = {
+  idle: "0 0 70px 8px rgba(99,132,255,0.25)",
+  listening: "0 0 90px 16px rgba(56,189,248,0.4)",
+  thinking: "0 0 55px 6px rgba(167,139,250,0.35)",
+  speaking: "0 0 95px 18px rgba(129,140,248,0.45)",
+};
+
+export const AssistantOrb = () => {
+  const [state, setState] = useState<OrbState>("idle");
+  const [auto, setAuto] = useState(true);
+
+  // Auto-tour the states so the demo reads without interaction.
+  useEffect(() => {
+    if (!auto) return undefined;
+    const order: OrbState[] = ["idle", "listening", "thinking", "speaking"];
+    const interval = setInterval(() => {
+      setState((current) => order[(order.indexOf(current) + 1) % order.length] ?? "idle");
+    }, 3600);
+    return () => clearInterval(interval);
+  }, [auto]);
+
+  const active = STATES.find((s) => s.key === state);
+
+  return (
+    <div className="flex w-[460px] flex-col items-center rounded-3xl bg-[#0c0d13] px-8 pt-12 pb-8 shadow-2xl shadow-black/60 ring-1 ring-white/10 select-none">
+      {/* Orb assembly */}
+      <div className="relative flex h-[210px] w-full items-center justify-center">
+        {/* Listening ripples */}
+        <AnimatePresence>
+          {state === "listening" &&
+            [0, 1, 2].map((ring) => (
+              <motion.span
+                key={ring}
+                initial={{ scale: 0.85, opacity: 0 }}
+                animate={{ scale: 1.9, opacity: [0, 0.35, 0] }}
+                exit={{ opacity: 0 }}
+                transition={{
+                  duration: 1.9,
+                  repeat: Infinity,
+                  delay: ring * 0.63,
+                  ease: "easeOut",
+                }}
+                className="absolute size-[150px] rounded-full border border-sky-300/50"
+              />
+            ))}
+        </AnimatePresence>
+
+        {/* Thinking orbiters */}
+        <AnimatePresence>
+          {state === "thinking" && (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1, rotate: 360 }}
+              exit={{ opacity: 0 }}
+              transition={{
+                rotate: { duration: 3.2, repeat: Infinity, ease: "linear" },
+                opacity: { duration: 0.4 },
+              }}
+              className="absolute size-[190px]"
+            >
+              {[0, 120, 240].map((angle) => (
+                <span
+                  key={angle}
+                  className="absolute top-1/2 left-1/2 size-[7px] rounded-full bg-violet-300/80"
+                  style={{
+                    transform: `rotate(${String(angle)}deg) translateX(92px) translateY(-50%)`,
+                  }}
+                />
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* The orb */}
+        <motion.div
+          variants={ORB_VARIANTS}
+          animate={state}
+          style={{ boxShadow: GLOW[state] }}
+          className="relative size-[150px] rounded-full transition-shadow duration-700"
+        >
+          {/* Base body */}
+          <div
+            className="absolute inset-0 rounded-full"
+            style={{
+              background:
+                "radial-gradient(circle at 32% 28%, #b7c8ff 0%, #6384ff 34%, #3b2f8f 72%, #191542 100%)",
+            }}
+          />
+          {/* Swirl layer — blurred conic, speed encodes state */}
+          <motion.div
+            key={state}
+            animate={{ rotate: 360 }}
+            transition={{
+              duration: SWIRL_DURATION[state],
+              repeat: Infinity,
+              ease: "linear",
+            }}
+            className="absolute inset-[6%] rounded-full opacity-75"
+            style={{
+              background:
+                "conic-gradient(from 0deg, transparent 0%, rgba(125,211,252,0.55) 18%, transparent 40%, rgba(196,181,253,0.5) 62%, transparent 85%)",
+              filter: "blur(11px)",
+            }}
+          />
+          {/* Specular highlight */}
+          <div
+            className="absolute inset-0 rounded-full"
+            style={{
+              background:
+                "radial-gradient(circle at 30% 22%, rgba(255,255,255,0.55) 0%, rgba(255,255,255,0.08) 26%, transparent 48%)",
+            }}
+          />
+        </motion.div>
+      </div>
+
+      {/* State readout */}
+      <div className="mt-7 h-[46px] text-center">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={state}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -6 }}
+            transition={{ duration: 0.18 }}
+          >
+            <p className="text-[15px] font-semibold text-white capitalize">{state}</p>
+            <p className="mt-0.5 text-[11.5px] text-white/40">{active?.blurb}</p>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+
+      {/* Controls */}
+      <div className="mt-5 flex items-center gap-2">
+        <div className="flex gap-1 rounded-full bg-white/[0.06] p-1">
+          {STATES.map((s) => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => {
+                setAuto(false);
+                setState(s.key);
+              }}
+              className={`relative rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+                state === s.key ? "text-black" : "text-white/55 hover:text-white/80"
+              }`}
+            >
+              {state === s.key && (
+                <motion.span
+                  layoutId="orb-state-pill"
+                  className="absolute inset-0 rounded-full bg-white"
+                  transition={{ type: "spring", stiffness: 500, damping: 35 }}
+                />
+              )}
+              <span className="relative">{s.label}</span>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => setAuto((a) => !a)}
+          className={`rounded-full px-3 py-1.5 text-[11px] font-medium transition-colors ${
+            auto ? "bg-white/[0.12] text-white/85" : "bg-white/[0.05] text-white/40"
+          }`}
+        >
+          Auto
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/content/assistant-orb/meta.json
+++ b/content/assistant-orb/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Assistant Orb",
+  "description": "One orb, four moods — idle breathes, listening leans in and ripples, thinking contracts and swirls, speaking pulses in bursts. Read the state from motion alone.",
+  "tags": ["ai", "effects"]
+}

--- a/content/assistant-orb/package.json
+++ b/content/assistant-orb/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@uicapsule/assistant-orb",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./preview": "./preview.tsx"
+  },
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "motion": "^12.40.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/assistant-orb/preview.tsx
+++ b/content/assistant-orb/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { AssistantOrb } from "./assistant-orb";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_20%,#171921_0%,#0b0d13_55%,#040508_100%)] p-5">
+      <AssistantOrb />
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       '@uicapsule/ascii-renderer':
         specifier: workspace:*
         version: link:../../content/ascii-renderer
+      '@uicapsule/assistant-orb':
+        specifier: workspace:*
+        version: link:../../content/assistant-orb
       '@uicapsule/background-pixel-stars':
         specifier: workspace:*
         version: link:../../content/background-pixel-stars
@@ -307,6 +310,25 @@ importers:
       '@types/three':
         specifier: ^0.184.1
         version: 0.184.1
+
+  content/assistant-orb:
+    dependencies:
+      motion:
+        specifier: ^12.40.0
+        version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.15)
 
   content/background-pixel-stars:
     dependencies:


### PR DESCRIPTION
The orb-family entry: one orb whose state you can read from motion alone. Idle breathes slowly; listening scales up with three staggered ripple rings; thinking contracts while a blurred conic swirl spins 6× faster and violet dots orbit; speaking pulses in irregular bursts with a hot glow. Layered construction (radial body, spinning conic swirl, specular highlight) with per-state glow shadows. Auto-tour cycles the states; the segmented control pins one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `@uicapsule/assistant-orb`: a React orb with four motion-driven states (idle, listening, thinking, speaking) so you can read state from motion alone. Includes a preview and wires the package into the web app.

- **New Features**
  - `AssistantOrb` with per-state motion: idle breathes; listening scales with staggered ripple rings; thinking contracts with fast swirl and orbiting dots; speaking pulses with hot glow.
  - Auto-tour cycles states; segmented pill control selects a state; on-orb state readout with short blurb.
  - Layered build: radial body, blurred conic swirl with state-dependent speed, and specular highlight, plus per-state glow.

- **Dependencies**
  - Adds workspace package `@uicapsule/assistant-orb` and registers it in `apps/web/package.json`.
  - New dependency `motion@^12.40.0`; lockfile updated.

<sup>Written for commit d70be93e67338097fc12fa7c90c4a15a808624bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Preview recording

![assistant-orb](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/pr63-assistant-orb.gif)

_Recorded from the [Vercel preview](https://uicapsule-git-kyh-assistant-orb-kyh-io.vercel.app/preview-frame/assistant-orb)._
