### PR TITLE
feat: add voxel-landing — fly-through landing page in voxel space

### DIFF
--- a/content/voxel-landing/meta.json
+++ b/content/voxel-landing/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Voxel Landing",
+  "description": "Voxel hero that assembles from falling blocks, then a landing page you fly through with perspective scroll",
+  "tags": ["landing-pages", "pixel-art", "effects"]
+}

--- a/content/voxel-landing/meta.json
+++ b/content/voxel-landing/meta.json
@@ -1,5 +1,9 @@
 {
   "name": "Voxel Landing",
-  "description": "Voxel hero that assembles from falling blocks, then a landing page you fly through with perspective scroll",
-  "tags": ["landing-pages", "pixel-art", "effects"]
+  "description": "Isometric voxel diorama landing page — scroll pans diagonally through a living world of walkers, marquee signs, and ground-laid typography",
+  "tags": [
+    "landing-pages",
+    "pixel-art",
+    "effects"
+  ]
 }

--- a/content/voxel-landing/package.json
+++ b/content/voxel-landing/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@uicapsule/voxel-landing",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/voxel-landing/preview.tsx
+++ b/content/voxel-landing/preview.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { VoxelLanding } from "./voxel-landing";
+
+const Preview = () => {
+  return (
+    <main className="h-dvh w-full bg-[#0f1114]">
+      <VoxelLanding />
+    </main>
+  );
+};
+
+export default Preview;

--- a/content/voxel-landing/voxel-landing.tsx
+++ b/content/voxel-landing/voxel-landing.tsx
@@ -137,6 +137,51 @@ const buildFlatWord = (out: Voxel[], word: string, cx: number, cz: number, accen
   });
 };
 
+// Road centerline; movers follow it smoothly (the drawn tiles are rounded).
+const roadX = (z: number) => Math.sin(z * 0.16) * 4 + 4;
+
+// Torii-style gate straddling the road.
+const buildGate = (out: Voxel[], z: number, color: string) => {
+  const cx = Math.round(roadX(z));
+  for (let y = 0; y < 4; y++) {
+    out.push(vox({ x: cx - 4, y, z, color }));
+    out.push(vox({ x: cx + 4, y, z, color }));
+  }
+  for (let x = cx - 5; x <= cx + 5; x++) {
+    out.push(vox({ x, y: 4, z, color }));
+  }
+  out.push(vox({ x: cx, y: 5, z, size: 0.5, color: "#33363b" }));
+};
+
+// Fountain basin — the jets are animated per-frame.
+const FOUNTAIN = { x: -9, z: 30 };
+const buildFountain = (out: Voxel[]) => {
+  for (let dx = -4; dx <= 4; dx++) {
+    for (let dz = -4; dz <= 4; dz++) {
+      const r = Math.hypot(dx, dz);
+      if (r > 4.2) continue;
+      const seed = out.length;
+      if (r > 3.1) {
+        out.push(
+          vox({ x: FOUNTAIN.x + dx, y: 0, z: FOUNTAIN.z + dz, h: 0.3, color: "#c9ced3", seed }),
+        );
+      } else {
+        out.push(
+          vox({
+            x: FOUNTAIN.x + dx,
+            y: 0,
+            z: FOUNTAIN.z + dz,
+            h: 0.18,
+            color: hash(seed * 2.1) < 0.15 ? "#4a9de0" : "#3186d4",
+            seed,
+          }),
+        );
+      }
+    }
+  }
+  out.push(vox({ x: FOUNTAIN.x, y: 0, z: FOUNTAIN.z, size: 0.7, color: "#9aa0a6" }));
+};
+
 const buildTree = (out: Voxel[], x: number, z: number, seed: number) => {
   out.push(vox({ x, y: 0, z, size: 0.5, color: "#7a5a3a" }));
   out.push(vox({ x, y: 1, z, size: 0.5, color: "#7a5a3a" }));
@@ -158,6 +203,11 @@ const buildWorld = (): Voxel[] => {
 
   buildSign(out, "VOXEL", -8, 0);
   buildSign(out, "START", WORLD_LEN - 8, 4);
+
+  buildFountain(out);
+  buildGate(out, 45, "#e23d2e");
+  buildGate(out, 150, "#f0b429");
+  buildGate(out, 212, "#3fa945");
 
   buildFlatWord(out, "BUILD", -10, SECTION_GAP + 9, ACCENTS[1]);
   buildFlatWord(out, "STACK", -10, SECTION_GAP * 2 + 9, ACCENTS[2]);
@@ -209,7 +259,7 @@ const buildWorld = (): Voxel[] => {
   // Winding dash-road tying the whole strip together.
   for (let z = -14; z <= WORLD_LEN + 14; z++) {
     if (hash(z * 9.7) < 0.3) continue;
-    const x = Math.round(Math.sin(z * 0.16) * 4) + 4;
+    const x = Math.round(roadX(z));
     out.push(vox({ x, y: 0, z, size: 0.6, h: 0.12, color: "#4a9de0", kind: "road", seed: z }));
   }
 
@@ -516,14 +566,72 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
         push(bx + (flap ? 0.5 : -0.5), 6.2, bz, 0.3, 0.35, "#c9ced3", 1);
       }
 
-      // Clouds drifting high above.
+      // Clouds drifting high above, upwind (opposite the scroll direction).
+      const cloudSpan = WORLD_LEN + 60;
       for (let i = 0; i < 7; i++) {
-        const cz = ((hash(i * 11.1) * (WORLD_LEN + 60) + now * 0.5) % (WORLD_LEN + 60)) - 20;
+        const cz =
+          ((((hash(i * 11.1) * cloudSpan - now * 0.5) % cloudSpan) + cloudSpan) % cloudSpan) - 20;
         const cx = (hash(i * 5.3) - 0.5) * 26;
         const qz = Math.round(cz * 4) / 4;
         for (let p = 0; p < 4; p++) {
           push(cx + (p > 1 ? 0.8 : 0), 12 + (p % 2) * 0.3, qz + p - 1.5, 0.8, 0.7, "#e8ecef", 0.92);
         }
+      }
+
+      // Fountain jets: chunky water columns rising and collapsing.
+      for (let j = 0; j < 5; j++) {
+        const [jx, jz] = [
+          [0, 0],
+          [1.2, 0],
+          [-1.2, 0],
+          [0, 1.2],
+          [0, -1.2],
+        ][j]!;
+        const jetH = 1 + Math.floor((Math.sin(now * 2.2 + j * 1.7) + 1) * 1.4);
+        for (let y = 1; y <= jetH; y++) {
+          push(FOUNTAIN.x + jx, y * 0.6, FOUNTAIN.z + jz, 0.26, 0.5, "#4a9de0", 0.9);
+        }
+      }
+
+      // Trucks hauling cargo the full length of the road, one each way.
+      const truckSpan = WORLD_LEN + 40;
+      for (let i = 0; i < 2; i++) {
+        const p = (now * (2.8 + i * 0.6) + hash(i * 41.7) * truckSpan) % truckSpan;
+        const tz = i === 0 ? p - 20 : WORLD_LEN + 20 - p;
+        const qz = Math.round(tz * 4) / 4;
+        const tx = Math.round(roadX(qz) * 4) / 4;
+        push(tx, 0, qz + (i === 0 ? 0.7 : -0.7), 0.5, 0.7, "#e8ecef", 1);
+        push(tx, 0, qz - (i === 0 ? 0.5 : -0.5), 0.62, 1, ACCENTS[(i * 2 + 1) % 4]!, 1);
+      }
+
+      // Duck train waddling the road end to end.
+      const duckSpan = WORLD_LEN + 20;
+      const duckLead = (now * 0.8 + 5) % duckSpan;
+      for (let k = 0; k < 4; k++) {
+        const dz = duckLead - k * 1.4 - 10;
+        const qz = Math.round(dz * 4) / 4;
+        const dx = Math.round((roadX(qz) + 1.6) * 4) / 4;
+        const waddle = (tick + k) % 2 === 0 ? 0.06 : 0;
+        const s = k === 0 ? 1 : 0.7;
+        push(dx, waddle, qz, 0.34 * s, 0.45 * s, "#e8ecef", 1);
+        push(dx, 0.45 * s + waddle, qz + 0.22, 0.18 * s, 0.3 * s, "#f0b429", 1);
+      }
+
+      // Snail circling the pond — the slowest thing alive here.
+      const snailA = now * 0.12;
+      const sx = Math.round((12 + Math.cos(snailA) * 6.5) * 4) / 4;
+      const sz = Math.round((SECTION_GAP * 3 + Math.sin(snailA) * 9.5) * 4) / 4;
+      push(sx, 0, sz, 0.32, 0.3, "#b98d4f", 1);
+      push(sx, 0.3, sz - 0.2, 0.26, 0.4, "#f0b429", 1);
+
+      // Hot-air balloons floating clean across the screen.
+      for (let i = 0; i < 2; i++) {
+        const bx = ((now * 1.1 + hash(i * 23.9) * 84) % 84) - 42;
+        const bz = 30 + hash(i * 9.7) * (WORLD_LEN - 40);
+        const qx = Math.round(bx * 4) / 4;
+        const lift = Math.round(Math.sin(now * 0.7 + i * 2.4) * 2) / 4;
+        push(qx, 10.4 + lift, bz, 0.5, 0.5, "#7a5a3a", 1);
+        push(qx, 11.4 + lift, bz, 1.1, 1.1, ACCENTS[(i * 3) % 4]!, 1);
       }
 
       drawables.sort((a, b) => a.depth - b.depth);

--- a/content/voxel-landing/voxel-landing.tsx
+++ b/content/voxel-landing/voxel-landing.tsx
@@ -25,6 +25,8 @@ const FONT: Record<string, string[]> = {
 
 const ACCENTS = ["#e23d2e", "#f0b429", "#3fa945", "#3186d4"] as const;
 
+// The corridor runs along +z; scrolling pans the camera so the world
+// slides up-right on screen (matching classic iso site scroll).
 const SECTION_GAP = 60;
 const SECTIONS = [
   { word: "VOXEL", accent: ACCENTS[0] },
@@ -36,6 +38,7 @@ const SECTIONS = [
 const WORLD_LEN = SECTION_GAP * (SECTIONS.length - 1);
 
 const TILE = 13; // iso half-width of a unit cube, in px
+const HALF = TILE * 0.5;
 const GRASS = ["#2c7a33", "#3fa945", "#57b85e"] as const;
 
 // Deterministic randomness — every load (and recording) is identical.
@@ -60,9 +63,9 @@ const shade = (hex: string, factor: number) => {
 type Kind = "static" | "sign" | "road";
 
 type Voxel = {
-  x: number; // world tiles, camera travels +x
+  x: number; // across the corridor
   y: number; // up, in tiles
-  z: number; // depth across the corridor
+  z: number; // along the corridor — the camera travels +z
   size: number; // horizontal scale (1 = full tile)
   h: number; // vertical scale
   color: string;
@@ -82,18 +85,17 @@ const vox = (partial: Partial<Voxel> & Pick<Voxel, "x" | "y" | "z" | "color">): 
   ...partial,
 });
 
-// Upright marquee sign: hollow dark frame + floating glyph cells, facing the camera.
-const buildSign = (out: Voxel[], word: string, cx: number, section: number) => {
+// Upright marquee sign: hollow dark frame + floating glyph cells, spanning x.
+const buildSign = (out: Voxel[], word: string, cz: number, section: number) => {
   const cols = word.length * 6 - 1;
   const half = Math.floor(cols / 2) + 2;
-  const zs = -8;
   for (let x = -half; x <= half; x++) {
-    out.push(vox({ x: cx + x, y: 1, z: zs, color: "#33363b" }));
-    out.push(vox({ x: cx + x, y: 9, z: zs, color: "#33363b" }));
+    out.push(vox({ x, y: 1, z: cz, color: "#33363b" }));
+    out.push(vox({ x, y: 9, z: cz, color: "#33363b" }));
   }
   for (let y = 2; y <= 8; y++) {
-    out.push(vox({ x: cx - half, y, z: zs, color: "#33363b" }));
-    out.push(vox({ x: cx + half, y, z: zs, color: "#33363b" }));
+    out.push(vox({ x: -half, y, z: cz, color: "#33363b" }));
+    out.push(vox({ x: half, y, z: cz, color: "#33363b" }));
   }
   word.split("").forEach((ch, li) => {
     const glyph = FONT[ch];
@@ -101,16 +103,16 @@ const buildSign = (out: Voxel[], word: string, cx: number, section: number) => {
     glyph.forEach((row, gy) => {
       row.split("").forEach((cell, gx) => {
         if (cell !== "#") return;
-        const x = cx + li * 6 + gx - cols / 2;
+        const x = li * 6 + gx - cols / 2;
         out.push(
-          vox({ x, y: 7 - gy, z: zs, color: "#62666c", kind: "sign", section, seed: out.length }),
+          vox({ x, y: 7 - gy, z: cz, color: "#62666c", kind: "sign", section, seed: out.length }),
         );
       });
     });
   });
 };
 
-// Word laid flat on the ground plane, rows running along z.
+// Word laid flat on the ground plane, glyphs running along x, rows along z.
 const buildFlatWord = (out: Voxel[], word: string, cx: number, cz: number, accent: string) => {
   const cols = word.length * 6 - 1;
   word.split("").forEach((ch, li) => {
@@ -154,23 +156,24 @@ const buildTree = (out: Voxel[], x: number, z: number, seed: number) => {
 const buildWorld = (): Voxel[] => {
   const out: Voxel[] = [];
 
-  buildSign(out, "VOXEL", 0, 0);
-  buildSign(out, "START", WORLD_LEN, 4);
+  buildSign(out, "VOXEL", -8, 0);
+  buildSign(out, "START", WORLD_LEN - 8, 4);
 
-  buildFlatWord(out, "BUILD", SECTION_GAP, 9, ACCENTS[1]);
-  buildFlatWord(out, "STACK", SECTION_GAP * 2, 9, ACCENTS[2]);
-  buildFlatWord(out, "SHIP", SECTION_GAP * 3, 9, ACCENTS[3]);
+  buildFlatWord(out, "BUILD", -10, SECTION_GAP + 9, ACCENTS[1]);
+  buildFlatWord(out, "STACK", -10, SECTION_GAP * 2 + 9, ACCENTS[2]);
+  buildFlatWord(out, "SHIP", -10, SECTION_GAP * 3 + 9, ACCENTS[3]);
 
-  // BUILD: a grove behind the word.
-  buildTree(out, SECTION_GAP - 12, -11, 0);
-  buildTree(out, SECTION_GAP - 2, -14, 1);
-  buildTree(out, SECTION_GAP + 9, -10, 2);
-  buildTree(out, SECTION_GAP + 16, -13, 0);
+  // BUILD: a grove flanking the word.
+  buildTree(out, 13, SECTION_GAP - 12, 0);
+  buildTree(out, 15, SECTION_GAP - 2, 1);
+  buildTree(out, 12, SECTION_GAP + 9, 2);
+  buildTree(out, 16, SECTION_GAP + 16, 0);
+  buildTree(out, -16, SECTION_GAP + 2, 1);
 
   // STACK: a bar-chart skyline of cube towers.
   for (let i = 0; i < 12; i++) {
-    const tx = SECTION_GAP * 2 + Math.floor((hash(i * 7.9) - 0.5) * 30);
-    const tz = -8 - Math.floor(hash(i * 3.3) * 8);
+    const tz = SECTION_GAP * 2 + Math.floor((hash(i * 7.9) - 0.5) * 30);
+    const tx = 10 + Math.floor(hash(i * 3.3) * 8);
     const height = 2 + Math.floor(hash(i * 5.1) * 5);
     for (let y = 0; y < height; y++) {
       const topmost = y === height - 1;
@@ -185,16 +188,16 @@ const buildWorld = (): Voxel[] => {
     }
   }
 
-  // SHIP: pond of flat water tiles.
-  for (let dx = -8; dx <= 8; dx++) {
-    for (let dz = -5; dz <= 5; dz++) {
-      if ((dx / 8) ** 2 + (dz / 5) ** 2 > 1) continue;
+  // SHIP: pond of flat water tiles beside the word.
+  for (let dz = -8; dz <= 8; dz++) {
+    for (let dx = -5; dx <= 5; dx++) {
+      if ((dz / 8) ** 2 + (dx / 5) ** 2 > 1) continue;
       const seed = out.length;
       out.push(
         vox({
-          x: SECTION_GAP * 3 + dx,
+          x: 12 + dx,
           y: 0,
-          z: -10 + dz,
+          z: SECTION_GAP * 3 + dz,
           h: 0.18,
           color: hash(seed * 2.1) < 0.15 ? "#4a9de0" : "#3186d4",
           seed,
@@ -204,26 +207,24 @@ const buildWorld = (): Voxel[] => {
   }
 
   // Winding dash-road tying the whole strip together.
-  for (let x = -14; x <= WORLD_LEN + 14; x++) {
-    if (hash(x * 9.7) < 0.3) continue;
-    const z = Math.round(Math.sin(x * 0.16) * 4);
-    out.push(
-      vox({ x, y: 0, z, size: 0.6, h: 0.12, color: "#4a9de0", kind: "road", seed: x }),
-    );
+  for (let z = -14; z <= WORLD_LEN + 14; z++) {
+    if (hash(z * 9.7) < 0.3) continue;
+    const x = Math.round(Math.sin(z * 0.16) * 4) + 4;
+    out.push(vox({ x, y: 0, z, size: 0.6, h: 0.12, color: "#4a9de0", kind: "road", seed: z }));
   }
 
   // Flag poles along the road.
   for (let i = 0; i < 14; i++) {
-    const px = Math.floor(hash(i * 13.7) * (WORLD_LEN + 20)) - 10;
-    const pz = Math.round(Math.sin(px * 0.16) * 4) + (hash(i * 3.9) < 0.5 ? 3 : -3);
+    const pz = Math.floor(hash(i * 13.7) * (WORLD_LEN + 20)) - 10;
+    const px = Math.round(Math.sin(pz * 0.16) * 4) + 4 + (hash(i * 3.9) < 0.5 ? 3 : -3);
     out.push(vox({ x: px, y: 0, z: pz, size: 0.22, h: 3, color: "#7d838a" }));
     out.push(vox({ x: px, y: 3, z: pz, size: 0.5, color: ACCENTS[i % 4] }));
   }
 
   // Flora scattered across the whole corridor.
   for (let i = 0; i < 260; i++) {
-    const fx = Math.floor(hash(i * 17.3) * (WORLD_LEN + 36)) - 18;
-    const fz = Math.floor((hash(i * 23.1) - 0.5) * 34);
+    const fz = Math.floor(hash(i * 17.3) * (WORLD_LEN + 36)) - 18;
+    const fx = Math.floor((hash(i * 23.1) - 0.5) * 34);
     const roll = hash(i * 5.9);
     if (roll < 0.72) {
       out.push(vox({ x: fx, y: 0, z: fz, size: 0.4, h: 0.5, color: GRASS[i % 3] }));
@@ -249,15 +250,15 @@ const buildWalkers = (): Walker[] => {
       id: walkers.length,
     });
   };
-  for (let i = 0; i < 5; i++) add(Math.floor(hash(i * 3.1) * 24) - 12, 4 + i * 2, 5);
-  add(SECTION_GAP - 8, 2, 6);
-  add(SECTION_GAP + 6, 16, 6);
-  add(SECTION_GAP * 2 + 4, 3, 6);
-  add(SECTION_GAP * 2 - 10, 17, 5);
-  add(SECTION_GAP * 3 - 6, 2, 5);
-  add(SECTION_GAP * 3 + 8, 16, 5);
+  for (let i = 0; i < 5; i++) add(4 + i * 2, Math.floor(hash(i * 3.1) * 24) - 12, 5);
+  add(2, SECTION_GAP - 8, 6);
+  add(16, SECTION_GAP + 6, 6);
+  add(3, SECTION_GAP * 2 + 4, 6);
+  add(17, SECTION_GAP * 2 - 10, 5);
+  add(2, SECTION_GAP * 3 - 6, 5);
+  add(16, SECTION_GAP * 3 + 8, 5);
   for (let i = 0; i < 9; i++) {
-    add(WORLD_LEN + Math.floor(hash(i * 7.7) * 22) - 11, 2 + Math.floor(hash(i * 4.3) * 10), 4);
+    add(2 + Math.floor(hash(i * 4.3) * 10), WORLD_LEN + Math.floor(hash(i * 7.7) * 22) - 11, 4);
   }
   return walkers;
 };
@@ -276,6 +277,40 @@ const walkerPos = (w: Walker, t: number): [number, number, boolean] => {
   const z = Math.round((az + (bz - az) * ease) * 2) / 2;
   return [x, z, frac < 0.7];
 };
+
+// HTML copy laid into the iso ground plane, y-n10 style.
+// matrix(1,.5,-1,.5): css X → world +x (down-right), css Y → world +z.
+// matrix(1,-.5,1,.5): text running up-right along world −z, for the hero.
+const GROUND = "matrix(1, 0.5, -1, 0.5, 0, 0)";
+const GROUND_CROSS = "matrix(1, -0.5, 1, 0.5, 0, 0)";
+
+type Label = {
+  x: number;
+  z: number;
+  matrix: string;
+  lines: [string, string];
+  size: string;
+};
+
+const LABELS: Label[] = [
+  {
+    x: 14,
+    z: 4,
+    matrix: GROUND_CROSS,
+    lines: ["Voxelworks", "A tiny nation of cubes"],
+    size: "text-xl",
+  },
+  { x: 2, z: SECTION_GAP + 16, matrix: GROUND, lines: ["01. Build", "Plant the grove"], size: "text-sm" },
+  { x: 2, z: SECTION_GAP * 2 + 16, matrix: GROUND, lines: ["02. Stack", "Raise the skyline"], size: "text-sm" },
+  { x: 2, z: SECTION_GAP * 3 + 16, matrix: GROUND, lines: ["03. Ship", "Cross the pond"], size: "text-sm" },
+  {
+    x: 10,
+    z: WORLD_LEN + 4,
+    matrix: GROUND,
+    lines: ["04. Start", "Join the world"],
+    size: "text-sm",
+  },
+];
 
 type VoxelLandingProps = {
   autoTour?: boolean;
@@ -318,13 +353,15 @@ const tourScroll = (t: number) => {
 export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const htmlRef = useRef<HTMLDivElement | null>(null);
   const [sectionIdx, setSectionIdx] = useState(0);
   const [moved, setMoved] = useState(false);
 
   useEffect(() => {
     const container = containerRef.current;
     const canvas = canvasRef.current;
-    if (!container || !canvas) return;
+    const htmlLayer = htmlRef.current;
+    if (!container || !canvas || !htmlLayer) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
@@ -373,8 +410,6 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
     let shownMoved = false;
     const start = performance.now();
 
-    const hw = TILE;
-    const hh = TILE * 0.5;
     const vy = TILE * 1.05;
 
     type Drawable = {
@@ -391,25 +426,29 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
       raf = requestAnimationFrame(frame);
       if (nowMs - last < 1000 / 30) return;
       last = nowMs;
-      const now = reducedMotion ? 0 : (nowMs - start) / 1000;
+      const elapsed = (nowMs - start) / 1000;
+      const now = reducedMotion ? 0 : elapsed;
 
       if (autoTour && !reducedMotion) {
-        if ((nowMs - start) / 1000 - lastInput < 4) {
-          if (pausedAt === null) pausedAt = (nowMs - start) / 1000;
+        if (elapsed - lastInput < 4) {
+          if (pausedAt === null) pausedAt = elapsed;
         } else {
           if (pausedAt !== null) {
-            tourOffset += (nowMs - start) / 1000 - pausedAt;
+            tourOffset += elapsed - pausedAt;
             pausedAt = null;
           }
-          target = tourScroll((nowMs - start) / 1000 - tourOffset);
+          target = tourScroll(elapsed - tourOffset);
         }
       }
 
       scroll += (target - scroll) * 0.09;
-      const camX = scroll * WORLD_LEN;
-      // Camera anchor: keep world point (camX, 0, 0) at a fixed screen spot.
-      const offX = width / 2 - camX * TILE;
-      const offY = height * 0.52 - camX * TILE * 0.5;
+      const camZ = scroll * WORLD_LEN;
+      // Keep world point (0, 0, camZ) at a fixed screen anchor: as camZ grows
+      // the world slides up-right, matching the original's scroll direction.
+      const offX = width / 2 + camZ * TILE;
+      const offY = height * 0.52 - camZ * HALF;
+
+      htmlLayer.style.transform = `translate3d(${offX}px, ${offY}px, 0)`;
 
       ctx.fillStyle = dotPattern ?? "#0f1114";
       ctx.fillRect(0, 0, width, height);
@@ -439,7 +478,7 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
         alpha: number,
       ) => {
         const sx = (x - z) * TILE + offX;
-        const sy = (x + z) * hh + offY - y * vy;
+        const sy = (x + z) * HALF + offY - y * vy;
         if (sx < -70 || sx > width + 70 || sy < -90 || sy > height + 90) return;
         drawables.push({ depth: (x + z) * 1000 + y, sx, sy, size, h, color, alpha });
       };
@@ -470,8 +509,8 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
 
       // Birds crossing the corridor.
       for (let i = 0; i < 5; i++) {
-        const bx = 20 + hash(i * 19.3) * (WORLD_LEN - 20);
-        const bz = ((now * 2.4 + hash(i * 7.7) * 40) % 44) - 22;
+        const bz = 20 + hash(i * 19.3) * (WORLD_LEN - 20);
+        const bx = ((now * 2.4 + hash(i * 7.7) * 40) % 44) - 22;
         const flap = (tick + i) % 2 === 0;
         push(bx, 6, bz, 0.42, 0.5, "#e8ecef", 1);
         push(bx + (flap ? 0.5 : -0.5), 6.2, bz, 0.3, 0.35, "#c9ced3", 1);
@@ -479,19 +518,19 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
 
       // Clouds drifting high above.
       for (let i = 0; i < 7; i++) {
-        const cx = ((hash(i * 11.1) * (WORLD_LEN + 60) + now * 0.5) % (WORLD_LEN + 60)) - 20;
-        const cz = (hash(i * 5.3) - 0.5) * 26;
-        const qx = Math.round(cx * 4) / 4;
+        const cz = ((hash(i * 11.1) * (WORLD_LEN + 60) + now * 0.5) % (WORLD_LEN + 60)) - 20;
+        const cx = (hash(i * 5.3) - 0.5) * 26;
+        const qz = Math.round(cz * 4) / 4;
         for (let p = 0; p < 4; p++) {
-          push(qx + p - 1.5, 12 + (p % 2) * 0.3, cz + (p > 1 ? 0.8 : 0), 0.8, 0.7, "#e8ecef", 0.92);
+          push(cx + (p > 1 ? 0.8 : 0), 12 + (p % 2) * 0.3, qz + p - 1.5, 0.8, 0.7, "#e8ecef", 0.92);
         }
       }
 
       drawables.sort((a, b) => a.depth - b.depth);
 
       for (const d of drawables) {
-        const w2 = hw * d.size;
-        const h2 = hh * d.size;
+        const w2 = TILE * d.size;
+        const h2 = HALF * d.size;
         const v2 = vy * d.h;
         ctx.globalAlpha = d.alpha;
         // top
@@ -574,6 +613,30 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
       className="relative h-full w-full touch-none select-none overflow-hidden bg-[#0f1114]"
     >
       <canvas ref={canvasRef} className="absolute inset-0" />
+
+      {/* HTML copy anchored into the iso world; the layer pans with the camera. */}
+      <div
+        ref={htmlRef}
+        className="pointer-events-none absolute left-0 top-0 will-change-transform"
+      >
+        {LABELS.map((label) => (
+          <div
+            key={label.lines[0]}
+            className="absolute whitespace-nowrap"
+            style={{
+              transform: `translate(${(label.x - label.z) * TILE}px, ${(label.x + label.z) * HALF}px) ${label.matrix}`,
+              transformOrigin: "0 0",
+            }}
+          >
+            <div className={`${label.size} font-bold tracking-[0.2em] text-neutral-200`}>
+              {label.lines[0]}
+            </div>
+            <div className="text-[10px] uppercase tracking-[0.3em] text-neutral-500">
+              {label.lines[1]}
+            </div>
+          </div>
+        ))}
+      </div>
 
       <div className="pointer-events-none absolute inset-0 font-mono uppercase">
         <div className="absolute left-6 top-5 flex items-center gap-2 text-[11px] font-bold tracking-[0.35em] text-neutral-200">

--- a/content/voxel-landing/voxel-landing.tsx
+++ b/content/voxel-landing/voxel-landing.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// 5x5 pixel font — only the glyphs the stations need.
+const FONT: Record<string, string[]> = {
+  A: [".###.", "#...#", "#####", "#...#", "#...#"],
+  B: ["####.", "#...#", "####.", "#...#", "####."],
+  C: [".####", "#....", "#....", "#....", ".####"],
+  D: ["####.", "#...#", "#...#", "#...#", "####."],
+  E: ["#####", "#....", "####.", "#....", "#####"],
+  H: ["#...#", "#...#", "#####", "#...#", "#...#"],
+  I: ["#####", "..#..", "..#..", "..#..", "#####"],
+  K: ["#...#", "#..#.", "###..", "#..#.", "#...#"],
+  L: ["#....", "#....", "#....", "#....", "#####"],
+  O: [".###.", "#...#", "#...#", "#...#", ".###."],
+  P: ["####.", "#...#", "####.", "#....", "#...."],
+  R: ["####.", "#...#", "####.", "#..#.", "#...#"],
+  S: [".####", "#....", ".###.", "....#", "####."],
+  T: ["#####", "..#..", "..#..", "..#..", "..#.."],
+  U: ["#...#", "#...#", "#...#", "#...#", ".###."],
+  V: ["#...#", "#...#", "#...#", ".#.#.", "..#.."],
+  X: ["#...#", ".#.#.", "..#..", ".#.#.", "#...#"],
+};
+
+const ACCENTS = ["#e23d2e", "#f0b429", "#3fa945", "#3186d4"] as const;
+
+type Station = {
+  word: string;
+  accent: string;
+  z: number;
+};
+
+const STATION_GAP = 70;
+const STATIONS: Station[] = [
+  { word: "VOXEL", accent: ACCENTS[0], z: 0 },
+  { word: "BUILD", accent: ACCENTS[1], z: STATION_GAP },
+  { word: "STACK", accent: ACCENTS[2], z: STATION_GAP * 2 },
+  { word: "SHIP", accent: ACCENTS[3], z: STATION_GAP * 3 },
+  { word: "START", accent: ACCENTS[0], z: STATION_GAP * 4 },
+];
+
+const VIEW_DIST = 45; // camera-to-station distance when a station is "arrived at"
+const TRACK = STATIONS[STATIONS.length - 1]!.z; // camZ travels [-VIEW_DIST, TRACK - VIEW_DIST]
+
+const GRAYS = ["#c9ced3", "#b3bac1", "#d8dce0"] as const;
+const QUANT_STEPS = 6; // assembly/scatter animate in chunky steps, not smoothly
+
+// Deterministic per-voxel randomness so every load (and recording) is identical.
+const hash = (n: number) => {
+  const s = Math.sin(n * 127.1 + 311.7) * 43758.5453;
+  return s - Math.floor(s);
+};
+
+const shadeCache = new Map<string, string>();
+const shade = (hex: string, factor: number) => {
+  const key = `${hex}:${factor}`;
+  const cached = shadeCache.get(key);
+  if (cached) return cached;
+  const r = Math.round(parseInt(hex.slice(1, 3), 16) * factor);
+  const g = Math.round(parseInt(hex.slice(3, 5), 16) * factor);
+  const b = Math.round(parseInt(hex.slice(5, 7), 16) * factor);
+  const out = `rgb(${r},${g},${b})`;
+  shadeCache.set(key, out);
+  return out;
+};
+
+type Voxel = {
+  x: number;
+  y: number;
+  z: number;
+  station: number;
+  seed: number;
+  accent: boolean;
+  scatterX: number;
+  scatterY: number;
+  dropY: number;
+};
+
+const buildStationVoxels = (): Voxel[] => {
+  const voxels: Voxel[] = [];
+  STATIONS.forEach((station, si) => {
+    const cols = station.word.length * 6 - 1;
+    station.word.split("").forEach((ch, li) => {
+      const glyph = FONT[ch];
+      if (!glyph) return;
+      glyph.forEach((row, gy) => {
+        row.split("").forEach((cell, gx) => {
+          if (cell !== "#") return;
+          const x = li * 6 + gx - cols / 2;
+          const y = gy - 2.5;
+          const seed = voxels.length;
+          const mag = Math.hypot(x, y) || 1;
+          voxels.push({
+            x,
+            y,
+            z: station.z,
+            station: si,
+            seed,
+            accent: hash(seed * 7.3) < 0.14,
+            scatterX: (x / mag + (hash(seed * 3.1) - 0.5) * 1.6) * 30,
+            scatterY: (y / mag + (hash(seed * 5.7) - 0.5) * 1.6) * 30,
+            dropY: -(16 + hash(seed * 2.3) * 14),
+          });
+        });
+      });
+    });
+  });
+  return voxels;
+};
+
+type Confetto = {
+  x: number;
+  y: number;
+  z: number;
+  color: string;
+  seed: number;
+};
+
+const buildConfetti = (): Confetto[] => {
+  const out: Confetto[] = [];
+  for (let i = 0; i < 70; i++) {
+    const colorRoll = hash(i * 11.3);
+    out.push({
+      x: (hash(i * 1.7) - 0.5) * 90,
+      y: (hash(i * 2.9) - 0.5) * 50,
+      z: hash(i * 4.3) * (TRACK + 60) - 25,
+      color: colorRoll < 0.55 ? ACCENTS[Math.floor(colorRoll * 20) % 4]! : GRAYS[1],
+      seed: i,
+    });
+  }
+  return out;
+};
+
+const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
+const quantize = (v: number) => Math.floor(clamp01(v) * QUANT_STEPS) / QUANT_STEPS;
+const easeInOut = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
+
+// Auto-tour keyframes: [time, scroll]. Holds at each station, long hold on START, rewind.
+const TOUR: [number, number][] = [
+  [0, 0],
+  [2.8, 0],
+  [4.6, 0.25],
+  [5.6, 0.25],
+  [7.4, 0.5],
+  [8.4, 0.5],
+  [10.2, 0.75],
+  [11.2, 0.75],
+  [13.0, 1],
+  [17.5, 1],
+  [19.5, 0],
+  [21.0, 0],
+];
+const TOUR_LENGTH = TOUR[TOUR.length - 1]![0];
+
+const tourScroll = (t: number) => {
+  const cycle = t % TOUR_LENGTH;
+  for (let i = 1; i < TOUR.length; i++) {
+    const [t1, s1] = TOUR[i]!;
+    const [t0, s0] = TOUR[i - 1]!;
+    if (cycle <= t1) {
+      const span = t1 - t0;
+      const p = span > 0 ? (cycle - t0) / span : 1;
+      return s0 + (s1 - s0) * easeInOut(p);
+    }
+  }
+  return 0;
+};
+
+type VoxelLandingProps = {
+  autoTour?: boolean;
+};
+
+export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [stationIdx, setStationIdx] = useState(0);
+  const [moved, setMoved] = useState(false);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    if (!container || !canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const voxels = buildStationVoxels();
+    const confetti = buildConfetti();
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    let width = 0;
+    let height = 0;
+    let dotPattern: CanvasPattern | null = null;
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio, 2);
+      width = container.clientWidth;
+      height = container.clientHeight;
+      canvas.width = Math.round(width * dpr);
+      canvas.height = Math.round(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      const tile = document.createElement("canvas");
+      tile.width = 18;
+      tile.height = 18;
+      const tileCtx = tile.getContext("2d");
+      if (tileCtx) {
+        tileCtx.fillStyle = "#0f1114";
+        tileCtx.fillRect(0, 0, 18, 18);
+        tileCtx.fillStyle = "#1a1d21";
+        tileCtx.fillRect(8, 8, 2, 2);
+        dotPattern = ctx.createPattern(tile, "repeat");
+      }
+    };
+    resize();
+    const observer = new ResizeObserver(resize);
+    observer.observe(container);
+
+    let scroll = 0;
+    let target = 0;
+    let lastInput = -Infinity;
+    let tourOffset = 0; // keeps the tour resumable after manual input
+    let pausedAt: number | null = null;
+    const triggers: (number | null)[] = STATIONS.map(() => null);
+    let raf = 0;
+    let last = 0;
+    let shownStation = 0;
+    let shownMoved = false;
+    const start = performance.now();
+
+    const frame = (nowMs: number) => {
+      raf = requestAnimationFrame(frame);
+      if (nowMs - last < 1000 / 30) return;
+      last = nowMs;
+      const now = (nowMs - start) / 1000;
+
+      // Auto-tour drives the scroll target unless the user recently intervened.
+      if (autoTour && !reducedMotion) {
+        if (now - lastInput < 4) {
+          if (pausedAt === null) pausedAt = now;
+        } else {
+          if (pausedAt !== null) {
+            tourOffset += now - pausedAt;
+            pausedAt = null;
+          }
+          target = tourScroll(now - tourOffset);
+        }
+      }
+
+      scroll += (target - scroll) * 0.09;
+      const camZ = -VIEW_DIST + scroll * TRACK;
+      const focal = width * 0.95;
+      const cx = width / 2;
+      const cy = height / 2;
+
+      ctx.fillStyle = dotPattern ?? "#0f1114";
+      ctx.fillRect(0, 0, width, height);
+
+      const nearest = Math.round(scroll * (STATIONS.length - 1));
+      if (nearest !== shownStation) {
+        shownStation = nearest;
+        setStationIdx(nearest);
+      }
+      if (!shownMoved && scroll > 0.02) {
+        shownMoved = true;
+        setMoved(true);
+      }
+
+      // Arm/reset per-station assembly timers based on camera proximity.
+      STATIONS.forEach((station, si) => {
+        const d = station.z - camZ;
+        if (d > -20 && d < 110 && triggers[si] === null) triggers[si] = now;
+        if ((d >= 130 || d <= -25) && triggers[si] !== null) triggers[si] = null;
+      });
+
+      const pulsePhase = Math.floor(now * 2.5);
+      const atFinale = nearest === STATIONS.length - 1 && Math.abs(scroll - 1) < 0.02;
+
+      type Drawable = {
+        x: number;
+        y: number;
+        z: number;
+        size: number;
+        color: string;
+        alpha: number;
+      };
+      const drawables: Drawable[] = [];
+
+      for (const c of confetti) {
+        const twinkle = 0.25 + 0.55 * Math.abs(Math.sin(now * 0.8 + c.seed * 2.1));
+        drawables.push({ x: c.x, y: c.y, z: c.z, size: 0.5, color: c.color, alpha: twinkle });
+      }
+
+      for (const v of voxels) {
+        const station = STATIONS[v.station]!;
+        const d = station.z - camZ;
+        if (d <= 0.4 || d > 130) continue;
+
+        const t0 = triggers[v.station];
+        const stagger = hash(v.seed * 9.1) * 0.9;
+        const timeP = t0 === null || reducedMotion ? 1 : clamp01((now - t0 - stagger) / 1.1);
+        const proxP = clamp01((110 - d) / 45);
+        const assembleQ = quantize(Math.min(timeP, proxP));
+        if (assembleQ <= 0) continue;
+
+        const scatterQ = quantize((22 - d) / 18);
+        const x = v.x + v.scatterX * scatterQ * scatterQ;
+        const y = v.y + v.dropY * (1 - assembleQ) + v.scatterY * scatterQ * scatterQ;
+        const alpha = assembleQ * (1 - clamp01((scatterQ - 0.5) * 2.2));
+        if (alpha <= 0.01) continue;
+
+        let color: string = v.accent ? station.accent : GRAYS[Math.floor(hash(v.seed * 4.7) * 3)]!;
+        if (atFinale && v.station === STATIONS.length - 1) {
+          const lit = hash(v.seed * 13.7 + pulsePhase * 3.3) < 0.3;
+          if (lit) color = ACCENTS[Math.floor(hash(v.seed + pulsePhase) * 4)]!;
+        }
+
+        drawables.push({ x, y, z: station.z, size: 0.45, color, alpha });
+      }
+
+      drawables.sort((a, b) => b.z - a.z);
+
+      for (const item of drawables) {
+        const df = item.z - camZ - item.size;
+        const db = item.z - camZ + item.size;
+        if (df <= 0.3) continue;
+        const sf = focal / df;
+        const sb = focal / db;
+        const fx = cx + item.x * sf;
+        const fy = cy + item.y * sf;
+        const bx = cx + item.x * sb;
+        const by = cy + item.y * sb;
+        const hf = item.size * sf;
+        const hb = item.size * sb;
+        if (fx + hf < 0 || fx - hf > width || fy + hf < 0 || fy - hf > height) continue;
+        if (hf < 0.75) continue;
+
+        ctx.globalAlpha = item.alpha;
+        const side = shade(item.color, 0.45);
+        const top = shade(item.color, 0.7);
+
+        // Side faces first (overdrawn by the front face where hidden).
+        ctx.fillStyle = side;
+        ctx.beginPath();
+        ctx.moveTo(fx - hf, fy - hf);
+        ctx.lineTo(bx - hb, by - hb);
+        ctx.lineTo(bx - hb, by + hb);
+        ctx.lineTo(fx - hf, fy + hf);
+        ctx.closePath();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.moveTo(fx + hf, fy - hf);
+        ctx.lineTo(bx + hb, by - hb);
+        ctx.lineTo(bx + hb, by + hb);
+        ctx.lineTo(fx + hf, fy + hf);
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = top;
+        ctx.beginPath();
+        ctx.moveTo(fx - hf, fy - hf);
+        ctx.lineTo(bx - hb, by - hb);
+        ctx.lineTo(bx + hb, by - hb);
+        ctx.lineTo(fx + hf, fy - hf);
+        ctx.closePath();
+        ctx.fill();
+        ctx.beginPath();
+        ctx.moveTo(fx - hf, fy + hf);
+        ctx.lineTo(bx - hb, by + hb);
+        ctx.lineTo(bx + hb, by + hb);
+        ctx.lineTo(fx + hf, fy + hf);
+        ctx.closePath();
+        ctx.fill();
+
+        ctx.fillStyle = item.color;
+        ctx.fillRect(fx - hf, fy - hf, hf * 2, hf * 2);
+      }
+      ctx.globalAlpha = 1;
+    };
+    raf = requestAnimationFrame(frame);
+
+    const nudge = (delta: number) => {
+      target = clamp01(target + delta);
+      lastInput = (performance.now() - start) / 1000;
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      nudge(e.deltaY * 0.0004);
+    };
+    container.addEventListener("wheel", onWheel, { passive: false });
+
+    let dragY: number | null = null;
+    const onPointerDown = (e: PointerEvent) => {
+      dragY = e.clientY;
+      container.setPointerCapture(e.pointerId);
+    };
+    const onPointerMove = (e: PointerEvent) => {
+      if (dragY === null) return;
+      nudge((dragY - e.clientY) * 0.0016);
+      dragY = e.clientY;
+    };
+    const onPointerUp = () => {
+      dragY = null;
+    };
+    container.addEventListener("pointerdown", onPointerDown);
+    container.addEventListener("pointermove", onPointerMove);
+    container.addEventListener("pointerup", onPointerUp);
+    container.addEventListener("pointercancel", onPointerUp);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+      container.removeEventListener("wheel", onWheel);
+      container.removeEventListener("pointerdown", onPointerDown);
+      container.removeEventListener("pointermove", onPointerMove);
+      container.removeEventListener("pointerup", onPointerUp);
+      container.removeEventListener("pointercancel", onPointerUp);
+    };
+  }, [autoTour]);
+
+  const accent = STATIONS[stationIdx]?.accent ?? ACCENTS[0];
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative h-full w-full touch-none select-none overflow-hidden bg-[#0f1114]"
+    >
+      <canvas ref={canvasRef} className="absolute inset-0" />
+
+      <div className="pointer-events-none absolute inset-0 font-mono uppercase">
+        <div className="absolute left-6 top-5 flex items-center gap-2 text-[11px] font-bold tracking-[0.35em] text-neutral-200">
+          <span className="inline-block size-2.5" style={{ backgroundColor: accent }} />
+          Voxelworks
+        </div>
+        <div className="absolute right-6 top-5 text-[10px] tracking-[0.3em] text-neutral-500">
+          STN 0{stationIdx + 1} / 0{STATIONS.length}
+        </div>
+
+        <div className="absolute bottom-5 left-1/2 flex -translate-x-1/2 gap-2">
+          {STATIONS.map((station, i) => (
+            <span
+              key={station.word}
+              className="size-2 border border-neutral-700 transition-colors duration-300"
+              style={i === stationIdx ? { backgroundColor: accent, borderColor: accent } : undefined}
+            />
+          ))}
+        </div>
+
+        <div className="absolute bottom-5 right-6 text-[10px] tracking-[0.3em] text-neutral-600">
+          {STATIONS[stationIdx]?.word}
+        </div>
+
+        <div
+          className={`absolute bottom-16 left-6 text-[10px] tracking-[0.3em] text-neutral-500 transition-opacity duration-700 ${moved ? "opacity-0" : "animate-pulse opacity-100"}`}
+        >
+          Scroll ▾
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/content/voxel-landing/voxel-landing.tsx
+++ b/content/voxel-landing/voxel-landing.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-// 5x5 pixel font — only the glyphs the stations need.
+// 5x5 pixel font — only the glyphs the sections need.
 const FONT: Record<string, string[]> = {
   A: [".###.", "#...#", "#####", "#...#", "#...#"],
   B: ["####.", "#...#", "####.", "#...#", "####."],
@@ -25,28 +25,20 @@ const FONT: Record<string, string[]> = {
 
 const ACCENTS = ["#e23d2e", "#f0b429", "#3fa945", "#3186d4"] as const;
 
-type Station = {
-  word: string;
-  accent: string;
-  z: number;
-};
+const SECTION_GAP = 60;
+const SECTIONS = [
+  { word: "VOXEL", accent: ACCENTS[0] },
+  { word: "BUILD", accent: ACCENTS[1] },
+  { word: "STACK", accent: ACCENTS[2] },
+  { word: "SHIP", accent: ACCENTS[3] },
+  { word: "START", accent: ACCENTS[0] },
+] as const;
+const WORLD_LEN = SECTION_GAP * (SECTIONS.length - 1);
 
-const STATION_GAP = 70;
-const STATIONS: Station[] = [
-  { word: "VOXEL", accent: ACCENTS[0], z: 0 },
-  { word: "BUILD", accent: ACCENTS[1], z: STATION_GAP },
-  { word: "STACK", accent: ACCENTS[2], z: STATION_GAP * 2 },
-  { word: "SHIP", accent: ACCENTS[3], z: STATION_GAP * 3 },
-  { word: "START", accent: ACCENTS[0], z: STATION_GAP * 4 },
-];
+const TILE = 13; // iso half-width of a unit cube, in px
+const GRASS = ["#2c7a33", "#3fa945", "#57b85e"] as const;
 
-const VIEW_DIST = 45; // camera-to-station distance when a station is "arrived at"
-const TRACK = STATIONS[STATIONS.length - 1]!.z; // camZ travels [-VIEW_DIST, TRACK - VIEW_DIST]
-
-const GRAYS = ["#c9ced3", "#b3bac1", "#d8dce0"] as const;
-const QUANT_STEPS = 6; // assembly/scatter animate in chunky steps, not smoothly
-
-// Deterministic per-voxel randomness so every load (and recording) is identical.
+// Deterministic randomness — every load (and recording) is identical.
 const hash = (n: number) => {
   const s = Math.sin(n * 127.1 + 311.7) * 43758.5453;
   return s - Math.floor(s);
@@ -65,78 +57,234 @@ const shade = (hex: string, factor: number) => {
   return out;
 };
 
+type Kind = "static" | "sign" | "road";
+
 type Voxel = {
-  x: number;
-  y: number;
-  z: number;
-  station: number;
+  x: number; // world tiles, camera travels +x
+  y: number; // up, in tiles
+  z: number; // depth across the corridor
+  size: number; // horizontal scale (1 = full tile)
+  h: number; // vertical scale
+  color: string;
+  alpha: number;
+  kind: Kind;
+  section: number; // for sign marquee cells
   seed: number;
-  accent: boolean;
-  scatterX: number;
-  scatterY: number;
-  dropY: number;
 };
 
-const buildStationVoxels = (): Voxel[] => {
-  const voxels: Voxel[] = [];
-  STATIONS.forEach((station, si) => {
-    const cols = station.word.length * 6 - 1;
-    station.word.split("").forEach((ch, li) => {
-      const glyph = FONT[ch];
-      if (!glyph) return;
-      glyph.forEach((row, gy) => {
-        row.split("").forEach((cell, gx) => {
-          if (cell !== "#") return;
-          const x = li * 6 + gx - cols / 2;
-          const y = gy - 2.5;
-          const seed = voxels.length;
-          const mag = Math.hypot(x, y) || 1;
-          voxels.push({
-            x,
-            y,
-            z: station.z,
-            station: si,
-            seed,
-            accent: hash(seed * 7.3) < 0.14,
-            scatterX: (x / mag + (hash(seed * 3.1) - 0.5) * 1.6) * 30,
-            scatterY: (y / mag + (hash(seed * 5.7) - 0.5) * 1.6) * 30,
-            dropY: -(16 + hash(seed * 2.3) * 14),
-          });
-        });
+const vox = (partial: Partial<Voxel> & Pick<Voxel, "x" | "y" | "z" | "color">): Voxel => ({
+  size: 1,
+  h: 1,
+  alpha: 1,
+  kind: "static",
+  section: -1,
+  seed: 0,
+  ...partial,
+});
+
+// Upright marquee sign: hollow dark frame + floating glyph cells, facing the camera.
+const buildSign = (out: Voxel[], word: string, cx: number, section: number) => {
+  const cols = word.length * 6 - 1;
+  const half = Math.floor(cols / 2) + 2;
+  const zs = -8;
+  for (let x = -half; x <= half; x++) {
+    out.push(vox({ x: cx + x, y: 1, z: zs, color: "#33363b" }));
+    out.push(vox({ x: cx + x, y: 9, z: zs, color: "#33363b" }));
+  }
+  for (let y = 2; y <= 8; y++) {
+    out.push(vox({ x: cx - half, y, z: zs, color: "#33363b" }));
+    out.push(vox({ x: cx + half, y, z: zs, color: "#33363b" }));
+  }
+  word.split("").forEach((ch, li) => {
+    const glyph = FONT[ch];
+    if (!glyph) return;
+    glyph.forEach((row, gy) => {
+      row.split("").forEach((cell, gx) => {
+        if (cell !== "#") return;
+        const x = cx + li * 6 + gx - cols / 2;
+        out.push(
+          vox({ x, y: 7 - gy, z: zs, color: "#62666c", kind: "sign", section, seed: out.length }),
+        );
       });
     });
   });
-  return voxels;
 };
 
-type Confetto = {
-  x: number;
-  y: number;
-  z: number;
-  color: string;
-  seed: number;
-};
-
-const buildConfetti = (): Confetto[] => {
-  const out: Confetto[] = [];
-  for (let i = 0; i < 70; i++) {
-    const colorRoll = hash(i * 11.3);
-    out.push({
-      x: (hash(i * 1.7) - 0.5) * 90,
-      y: (hash(i * 2.9) - 0.5) * 50,
-      z: hash(i * 4.3) * (TRACK + 60) - 25,
-      color: colorRoll < 0.55 ? ACCENTS[Math.floor(colorRoll * 20) % 4]! : GRAYS[1],
-      seed: i,
+// Word laid flat on the ground plane, rows running along z.
+const buildFlatWord = (out: Voxel[], word: string, cx: number, cz: number, accent: string) => {
+  const cols = word.length * 6 - 1;
+  word.split("").forEach((ch, li) => {
+    const glyph = FONT[ch];
+    if (!glyph) return;
+    glyph.forEach((row, gz) => {
+      row.split("").forEach((cell, gx) => {
+        if (cell !== "#") return;
+        const seed = out.length;
+        out.push(
+          vox({
+            x: cx + li * 6 + gx - cols / 2,
+            y: 0,
+            z: cz + gz,
+            h: 0.35,
+            color: hash(seed * 3.7) < 0.09 ? accent : "#8b9096",
+            seed,
+          }),
+        );
+      });
     });
+  });
+};
+
+const buildTree = (out: Voxel[], x: number, z: number, seed: number) => {
+  out.push(vox({ x, y: 0, z, size: 0.5, color: "#7a5a3a" }));
+  out.push(vox({ x, y: 1, z, size: 0.5, color: "#7a5a3a" }));
+  const canopy: [number, number, number][] = [
+    [0, 2, 0],
+    [1, 2, 0],
+    [-1, 2, 0],
+    [0, 2, 1],
+    [0, 2, -1],
+    [0, 3, 0],
+  ];
+  canopy.forEach(([dx, dy, dz], i) => {
+    out.push(vox({ x: x + dx, y: dy, z: z + dz, color: GRASS[(i + seed) % 3] }));
+  });
+};
+
+const buildWorld = (): Voxel[] => {
+  const out: Voxel[] = [];
+
+  buildSign(out, "VOXEL", 0, 0);
+  buildSign(out, "START", WORLD_LEN, 4);
+
+  buildFlatWord(out, "BUILD", SECTION_GAP, 9, ACCENTS[1]);
+  buildFlatWord(out, "STACK", SECTION_GAP * 2, 9, ACCENTS[2]);
+  buildFlatWord(out, "SHIP", SECTION_GAP * 3, 9, ACCENTS[3]);
+
+  // BUILD: a grove behind the word.
+  buildTree(out, SECTION_GAP - 12, -11, 0);
+  buildTree(out, SECTION_GAP - 2, -14, 1);
+  buildTree(out, SECTION_GAP + 9, -10, 2);
+  buildTree(out, SECTION_GAP + 16, -13, 0);
+
+  // STACK: a bar-chart skyline of cube towers.
+  for (let i = 0; i < 12; i++) {
+    const tx = SECTION_GAP * 2 + Math.floor((hash(i * 7.9) - 0.5) * 30);
+    const tz = -8 - Math.floor(hash(i * 3.3) * 8);
+    const height = 2 + Math.floor(hash(i * 5.1) * 5);
+    for (let y = 0; y < height; y++) {
+      const topmost = y === height - 1;
+      out.push(
+        vox({
+          x: tx,
+          y,
+          z: tz,
+          color: topmost ? ACCENTS[i % 4] : y % 2 === 0 ? "#5a5f66" : "#6b7076",
+        }),
+      );
+    }
   }
+
+  // SHIP: pond of flat water tiles.
+  for (let dx = -8; dx <= 8; dx++) {
+    for (let dz = -5; dz <= 5; dz++) {
+      if ((dx / 8) ** 2 + (dz / 5) ** 2 > 1) continue;
+      const seed = out.length;
+      out.push(
+        vox({
+          x: SECTION_GAP * 3 + dx,
+          y: 0,
+          z: -10 + dz,
+          h: 0.18,
+          color: hash(seed * 2.1) < 0.15 ? "#4a9de0" : "#3186d4",
+          seed,
+        }),
+      );
+    }
+  }
+
+  // Winding dash-road tying the whole strip together.
+  for (let x = -14; x <= WORLD_LEN + 14; x++) {
+    if (hash(x * 9.7) < 0.3) continue;
+    const z = Math.round(Math.sin(x * 0.16) * 4);
+    out.push(
+      vox({ x, y: 0, z, size: 0.6, h: 0.12, color: "#4a9de0", kind: "road", seed: x }),
+    );
+  }
+
+  // Flag poles along the road.
+  for (let i = 0; i < 14; i++) {
+    const px = Math.floor(hash(i * 13.7) * (WORLD_LEN + 20)) - 10;
+    const pz = Math.round(Math.sin(px * 0.16) * 4) + (hash(i * 3.9) < 0.5 ? 3 : -3);
+    out.push(vox({ x: px, y: 0, z: pz, size: 0.22, h: 3, color: "#7d838a" }));
+    out.push(vox({ x: px, y: 3, z: pz, size: 0.5, color: ACCENTS[i % 4] }));
+  }
+
+  // Flora scattered across the whole corridor.
+  for (let i = 0; i < 260; i++) {
+    const fx = Math.floor(hash(i * 17.3) * (WORLD_LEN + 36)) - 18;
+    const fz = Math.floor((hash(i * 23.1) - 0.5) * 34);
+    const roll = hash(i * 5.9);
+    if (roll < 0.72) {
+      out.push(vox({ x: fx, y: 0, z: fz, size: 0.4, h: 0.5, color: GRASS[i % 3] }));
+    } else {
+      out.push(vox({ x: fx, y: 0, z: fz, size: 0.16, h: 1, color: "#3fa945" }));
+      out.push(vox({ x: fx, y: 1, z: fz, size: 0.34, color: ACCENTS[i % 4] }));
+    }
+  }
+
   return out;
 };
 
+// Walkers wander around a home point; position is a pure function of time.
+type Walker = { home: [number, number]; radius: number; body: string; id: number };
+
+const buildWalkers = (): Walker[] => {
+  const walkers: Walker[] = [];
+  const add = (hx: number, hz: number, radius: number) => {
+    walkers.push({
+      home: [hx, hz],
+      radius,
+      body: ACCENTS[walkers.length % 4],
+      id: walkers.length,
+    });
+  };
+  for (let i = 0; i < 5; i++) add(Math.floor(hash(i * 3.1) * 24) - 12, 4 + i * 2, 5);
+  add(SECTION_GAP - 8, 2, 6);
+  add(SECTION_GAP + 6, 16, 6);
+  add(SECTION_GAP * 2 + 4, 3, 6);
+  add(SECTION_GAP * 2 - 10, 17, 5);
+  add(SECTION_GAP * 3 - 6, 2, 5);
+  add(SECTION_GAP * 3 + 8, 16, 5);
+  for (let i = 0; i < 9; i++) {
+    add(WORLD_LEN + Math.floor(hash(i * 7.7) * 22) - 11, 2 + Math.floor(hash(i * 4.3) * 10), 4);
+  }
+  return walkers;
+};
+
+const walkerPos = (w: Walker, t: number): [number, number, boolean] => {
+  const epoch = Math.floor(t / 2.6 + hash(w.id * 31.7));
+  const frac = (t / 2.6 + hash(w.id * 31.7)) % 1;
+  const wp = (k: number): [number, number] => [
+    w.home[0] + (hash(w.id * 91.3 + k * 17.1) - 0.5) * 2 * w.radius,
+    w.home[1] + (hash(w.id * 47.9 + k * 29.3) - 0.5) * 2 * w.radius,
+  ];
+  const [ax, az] = wp(epoch);
+  const [bx, bz] = wp(epoch + 1);
+  const ease = frac < 0.7 ? frac / 0.7 : 1; // walk, then idle at the waypoint
+  const x = Math.round((ax + (bx - ax) * ease) * 2) / 2;
+  const z = Math.round((az + (bz - az) * ease) * 2) / 2;
+  return [x, z, frac < 0.7];
+};
+
+type VoxelLandingProps = {
+  autoTour?: boolean;
+};
+
 const clamp01 = (v: number) => Math.min(1, Math.max(0, v));
-const quantize = (v: number) => Math.floor(clamp01(v) * QUANT_STEPS) / QUANT_STEPS;
 const easeInOut = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
 
-// Auto-tour keyframes: [time, scroll]. Holds at each station, long hold on START, rewind.
+// Auto-tour keyframes: [time, scroll]. Holds at each section, long hold on START, rewind.
 const TOUR: [number, number][] = [
   [0, 0],
   [2.8, 0],
@@ -167,14 +315,10 @@ const tourScroll = (t: number) => {
   return 0;
 };
 
-type VoxelLandingProps = {
-  autoTour?: boolean;
-};
-
 export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const [stationIdx, setStationIdx] = useState(0);
+  const [sectionIdx, setSectionIdx] = useState(0);
   const [moved, setMoved] = useState(false);
 
   useEffect(() => {
@@ -184,8 +328,8 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    const voxels = buildStationVoxels();
-    const confetti = buildConfetti();
+    const world = buildWorld();
+    const walkers = buildWalkers();
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
     let width = 0;
@@ -221,160 +365,162 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
     let scroll = 0;
     let target = 0;
     let lastInput = -Infinity;
-    let tourOffset = 0; // keeps the tour resumable after manual input
+    let tourOffset = 0;
     let pausedAt: number | null = null;
-    const triggers: (number | null)[] = STATIONS.map(() => null);
     let raf = 0;
     let last = 0;
-    let shownStation = 0;
+    let shownSection = 0;
     let shownMoved = false;
     const start = performance.now();
+
+    const hw = TILE;
+    const hh = TILE * 0.5;
+    const vy = TILE * 1.05;
+
+    type Drawable = {
+      depth: number;
+      sx: number;
+      sy: number;
+      size: number;
+      h: number;
+      color: string;
+      alpha: number;
+    };
 
     const frame = (nowMs: number) => {
       raf = requestAnimationFrame(frame);
       if (nowMs - last < 1000 / 30) return;
       last = nowMs;
-      const now = (nowMs - start) / 1000;
+      const now = reducedMotion ? 0 : (nowMs - start) / 1000;
 
-      // Auto-tour drives the scroll target unless the user recently intervened.
       if (autoTour && !reducedMotion) {
-        if (now - lastInput < 4) {
-          if (pausedAt === null) pausedAt = now;
+        if ((nowMs - start) / 1000 - lastInput < 4) {
+          if (pausedAt === null) pausedAt = (nowMs - start) / 1000;
         } else {
           if (pausedAt !== null) {
-            tourOffset += now - pausedAt;
+            tourOffset += (nowMs - start) / 1000 - pausedAt;
             pausedAt = null;
           }
-          target = tourScroll(now - tourOffset);
+          target = tourScroll((nowMs - start) / 1000 - tourOffset);
         }
       }
 
       scroll += (target - scroll) * 0.09;
-      const camZ = -VIEW_DIST + scroll * TRACK;
-      const focal = width * 0.95;
-      const cx = width / 2;
-      const cy = height / 2;
+      const camX = scroll * WORLD_LEN;
+      // Camera anchor: keep world point (camX, 0, 0) at a fixed screen spot.
+      const offX = width / 2 - camX * TILE;
+      const offY = height * 0.52 - camX * TILE * 0.5;
 
       ctx.fillStyle = dotPattern ?? "#0f1114";
       ctx.fillRect(0, 0, width, height);
 
-      const nearest = Math.round(scroll * (STATIONS.length - 1));
-      if (nearest !== shownStation) {
-        shownStation = nearest;
-        setStationIdx(nearest);
+      const nearest = Math.round(scroll * (SECTIONS.length - 1));
+      if (nearest !== shownSection) {
+        shownSection = nearest;
+        setSectionIdx(nearest);
       }
       if (!shownMoved && scroll > 0.02) {
         shownMoved = true;
         setMoved(true);
       }
 
-      // Arm/reset per-station assembly timers based on camera proximity.
-      STATIONS.forEach((station, si) => {
-        const d = station.z - camZ;
-        if (d > -20 && d < 110 && triggers[si] === null) triggers[si] = now;
-        if ((d >= 130 || d <= -25) && triggers[si] !== null) triggers[si] = null;
-      });
-
       const pulsePhase = Math.floor(now * 2.5);
-      const atFinale = nearest === STATIONS.length - 1 && Math.abs(scroll - 1) < 0.02;
+      const atFinale = nearest === SECTIONS.length - 1 && Math.abs(scroll - 1) < 0.02;
+      const tick = Math.floor(now / 0.16);
 
-      type Drawable = {
-        x: number;
-        y: number;
-        z: number;
-        size: number;
-        color: string;
-        alpha: number;
-      };
       const drawables: Drawable[] = [];
+      const push = (
+        x: number,
+        y: number,
+        z: number,
+        size: number,
+        h: number,
+        color: string,
+        alpha: number,
+      ) => {
+        const sx = (x - z) * TILE + offX;
+        const sy = (x + z) * hh + offY - y * vy;
+        if (sx < -70 || sx > width + 70 || sy < -90 || sy > height + 90) return;
+        drawables.push({ depth: (x + z) * 1000 + y, sx, sy, size, h, color, alpha });
+      };
 
-      for (const c of confetti) {
-        const twinkle = 0.25 + 0.55 * Math.abs(Math.sin(now * 0.8 + c.seed * 2.1));
-        drawables.push({ x: c.x, y: c.y, z: c.z, size: 0.5, color: c.color, alpha: twinkle });
-      }
-
-      for (const v of voxels) {
-        const station = STATIONS[v.station]!;
-        const d = station.z - camZ;
-        if (d <= 0.4 || d > 130) continue;
-
-        const t0 = triggers[v.station];
-        const stagger = hash(v.seed * 9.1) * 0.9;
-        const timeP = t0 === null || reducedMotion ? 1 : clamp01((now - t0 - stagger) / 1.1);
-        const proxP = clamp01((110 - d) / 45);
-        const assembleQ = quantize(Math.min(timeP, proxP));
-        if (assembleQ <= 0) continue;
-
-        const scatterQ = quantize((22 - d) / 18);
-        const x = v.x + v.scatterX * scatterQ * scatterQ;
-        const y = v.y + v.dropY * (1 - assembleQ) + v.scatterY * scatterQ * scatterQ;
-        const alpha = assembleQ * (1 - clamp01((scatterQ - 0.5) * 2.2));
-        if (alpha <= 0.01) continue;
-
-        let color: string = v.accent ? station.accent : GRAYS[Math.floor(hash(v.seed * 4.7) * 3)]!;
-        if (atFinale && v.station === STATIONS.length - 1) {
-          const lit = hash(v.seed * 13.7 + pulsePhase * 3.3) < 0.3;
-          if (lit) color = ACCENTS[Math.floor(hash(v.seed + pulsePhase) * 4)]!;
+      for (const v of world) {
+        let color = v.color;
+        let alpha = v.alpha;
+        if (v.kind === "sign") {
+          const rate = v.section === 4 && atFinale ? 0.34 : 0.16;
+          if (hash(v.seed * 13.7 + pulsePhase * 3.3) < rate) {
+            color = ACCENTS[Math.floor(hash(v.seed + pulsePhase) * 4)]!;
+          }
+        } else if (v.kind === "road") {
+          alpha = 0.35 + 0.65 * hash(v.seed * 7.1 + Math.floor(now * 3.2));
         }
-
-        drawables.push({ x, y, z: station.z, size: 0.45, color, alpha });
+        push(v.x, v.y, v.z, v.size, v.h, color, alpha);
       }
 
-      drawables.sort((a, b) => b.z - a.z);
+      // Walkers: legs alternate, tiny bob, everything snapped to half tiles.
+      for (const w of walkers) {
+        const [wx, wz, walking] = walkerPos(w, now);
+        const step = walking && (tick + w.id) % 2 === 0;
+        const bob = step ? 0.12 : 0;
+        push(wx, 0, wz, 0.42, step ? 0.85 : 1, "#23304a", 1);
+        push(wx, 1 + bob, wz, 0.62, 1, w.body, 1);
+        push(wx, 2 + bob, wz, 0.5, 0.9, "#dcc9a0", 1);
+      }
 
-      for (const item of drawables) {
-        const df = item.z - camZ - item.size;
-        const db = item.z - camZ + item.size;
-        if (df <= 0.3) continue;
-        const sf = focal / df;
-        const sb = focal / db;
-        const fx = cx + item.x * sf;
-        const fy = cy + item.y * sf;
-        const bx = cx + item.x * sb;
-        const by = cy + item.y * sb;
-        const hf = item.size * sf;
-        const hb = item.size * sb;
-        if (fx + hf < 0 || fx - hf > width || fy + hf < 0 || fy - hf > height) continue;
-        if (hf < 0.75) continue;
+      // Birds crossing the corridor.
+      for (let i = 0; i < 5; i++) {
+        const bx = 20 + hash(i * 19.3) * (WORLD_LEN - 20);
+        const bz = ((now * 2.4 + hash(i * 7.7) * 40) % 44) - 22;
+        const flap = (tick + i) % 2 === 0;
+        push(bx, 6, bz, 0.42, 0.5, "#e8ecef", 1);
+        push(bx + (flap ? 0.5 : -0.5), 6.2, bz, 0.3, 0.35, "#c9ced3", 1);
+      }
 
-        ctx.globalAlpha = item.alpha;
-        const side = shade(item.color, 0.45);
-        const top = shade(item.color, 0.7);
+      // Clouds drifting high above.
+      for (let i = 0; i < 7; i++) {
+        const cx = ((hash(i * 11.1) * (WORLD_LEN + 60) + now * 0.5) % (WORLD_LEN + 60)) - 20;
+        const cz = (hash(i * 5.3) - 0.5) * 26;
+        const qx = Math.round(cx * 4) / 4;
+        for (let p = 0; p < 4; p++) {
+          push(qx + p - 1.5, 12 + (p % 2) * 0.3, cz + (p > 1 ? 0.8 : 0), 0.8, 0.7, "#e8ecef", 0.92);
+        }
+      }
 
-        // Side faces first (overdrawn by the front face where hidden).
-        ctx.fillStyle = side;
+      drawables.sort((a, b) => a.depth - b.depth);
+
+      for (const d of drawables) {
+        const w2 = hw * d.size;
+        const h2 = hh * d.size;
+        const v2 = vy * d.h;
+        ctx.globalAlpha = d.alpha;
+        // top
+        ctx.fillStyle = d.color;
         ctx.beginPath();
-        ctx.moveTo(fx - hf, fy - hf);
-        ctx.lineTo(bx - hb, by - hb);
-        ctx.lineTo(bx - hb, by + hb);
-        ctx.lineTo(fx - hf, fy + hf);
+        ctx.moveTo(d.sx, d.sy - h2);
+        ctx.lineTo(d.sx + w2, d.sy);
+        ctx.lineTo(d.sx, d.sy + h2);
+        ctx.lineTo(d.sx - w2, d.sy);
         ctx.closePath();
         ctx.fill();
+        // left
+        ctx.fillStyle = shade(d.color, 0.62);
         ctx.beginPath();
-        ctx.moveTo(fx + hf, fy - hf);
-        ctx.lineTo(bx + hb, by - hb);
-        ctx.lineTo(bx + hb, by + hb);
-        ctx.lineTo(fx + hf, fy + hf);
+        ctx.moveTo(d.sx - w2, d.sy);
+        ctx.lineTo(d.sx, d.sy + h2);
+        ctx.lineTo(d.sx, d.sy + h2 + v2);
+        ctx.lineTo(d.sx - w2, d.sy + v2);
         ctx.closePath();
         ctx.fill();
-        ctx.fillStyle = top;
+        // right
+        ctx.fillStyle = shade(d.color, 0.4);
         ctx.beginPath();
-        ctx.moveTo(fx - hf, fy - hf);
-        ctx.lineTo(bx - hb, by - hb);
-        ctx.lineTo(bx + hb, by - hb);
-        ctx.lineTo(fx + hf, fy - hf);
+        ctx.moveTo(d.sx + w2, d.sy);
+        ctx.lineTo(d.sx, d.sy + h2);
+        ctx.lineTo(d.sx, d.sy + h2 + v2);
+        ctx.lineTo(d.sx + w2, d.sy + v2);
         ctx.closePath();
         ctx.fill();
-        ctx.beginPath();
-        ctx.moveTo(fx - hf, fy + hf);
-        ctx.lineTo(bx - hb, by + hb);
-        ctx.lineTo(bx + hb, by + hb);
-        ctx.lineTo(fx + hf, fy + hf);
-        ctx.closePath();
-        ctx.fill();
-
-        ctx.fillStyle = item.color;
-        ctx.fillRect(fx - hf, fy - hf, hf * 2, hf * 2);
       }
       ctx.globalAlpha = 1;
     };
@@ -420,7 +566,7 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
     };
   }, [autoTour]);
 
-  const accent = STATIONS[stationIdx]?.accent ?? ACCENTS[0];
+  const accent = SECTIONS[sectionIdx]?.accent ?? ACCENTS[0];
 
   return (
     <div
@@ -435,21 +581,21 @@ export const VoxelLanding = ({ autoTour = true }: VoxelLandingProps) => {
           Voxelworks
         </div>
         <div className="absolute right-6 top-5 text-[10px] tracking-[0.3em] text-neutral-500">
-          STN 0{stationIdx + 1} / 0{STATIONS.length}
+          STN 0{sectionIdx + 1} / 0{SECTIONS.length}
         </div>
 
         <div className="absolute bottom-5 left-1/2 flex -translate-x-1/2 gap-2">
-          {STATIONS.map((station, i) => (
+          {SECTIONS.map((section, i) => (
             <span
-              key={station.word}
+              key={section.word}
               className="size-2 border border-neutral-700 transition-colors duration-300"
-              style={i === stationIdx ? { backgroundColor: accent, borderColor: accent } : undefined}
+              style={i === sectionIdx ? { backgroundColor: accent, borderColor: accent } : undefined}
             />
           ))}
         </div>
 
         <div className="absolute bottom-5 right-6 text-[10px] tracking-[0.3em] text-neutral-600">
-          {STATIONS[stationIdx]?.word}
+          {SECTIONS[sectionIdx]?.word}
         </div>
 
         <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,6 +815,22 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
 
+  content/voxel-landing:
+    dependencies:
+      react:
+        specifier: 'catalog:'
+        version: 19.2.7
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+
   content/wireframe-orb:
     dependencies:
       '@react-three/drei':


### PR DESCRIPTION
A miniature landing "site" rendered as an isometric voxel diorama. Scroll (wheel or drag) pans the camera diagonally — the world slides up-right, matching the classic iso-site scroll axis — through five sections: VOXEL, BUILD, STACK, SHIP, START. Upright LED-marquee signs bookend the strip, their glyph cells reshuffling through a four-color palette; BUILD/STACK/SHIP are laid flat into the ground like plaza paving. Real HTML copy (hero heading + numbered section labels) is skewed onto the iso ground plane with CSS matrix transforms and pans with the camera. The world is populated on two layers of motion: constrained life (wandering walkers, an animated fountain, a snail circling the pond) and full-traverse life (two trucks hauling the road in opposite directions, a duck train waddling end to end, hot-air balloons and clouds crossing the whole screen — clouds drifting upwind, against the scroll). Three torii gates straddle the winding dash-road; arriving at START doubles the marquee flicker for a finale pulse. Interaction study of y-n10.com's post-enter isometric world; original layout, palette treatment, and content.

Construction: single 2D canvas, classic 2:1 iso projection with painter's-algorithm depth sort, a 17-glyph 5×5 pixel font shared by signs and ground words, a world-anchored DOM layer driven by the same camera offset each frame (`matrix(1,.5,-1,.5)` ground plane), deterministic per-voxel hashing — every mover's position is a pure function of time, so every load is identical — 30fps cap, keyframed 21s auto-tour that yields to input and resumes after idle, `prefers-reduced-motion` renders a static frame.

## Preview recording

![voxel-landing](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/voxel-landing.gif)

_Recorded locally from [`/preview-frame/voxel-landing`](https://uicapsule-git-kyh-voxel-landing-kyh-io.vercel.app/preview-frame/voxel-landing)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)