### PR TITLE
fix: triage React Doctor findings

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,6 @@
     "react-hook-form": "^7.81.0",
     "shiki": "^4.3.1",
     "superjson": "catalog:",
-    "three": "^0.185.1",
     "web-haptics": "^0.0.6",
     "zod": "catalog:"
   },

--- a/apps/web/src/app/(frame)/layout.tsx
+++ b/apps/web/src/app/(frame)/layout.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from "react";
 
+import { MotionProvider } from "@/components/motion-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 
 import "../styles/globals.css";
@@ -14,7 +15,7 @@ const FrameLayout = ({ children }: { children: ReactNode }) => {
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <MotionProvider>{children}</MotionProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/content-feed.tsx
@@ -149,6 +149,7 @@ export const ContentFeed = ({ initialSlug, feed }: ContentFeedProps) => {
       <div
         ref={containerRef}
         id="content-feed"
+        data-initial-slug={initialSlug}
         className="h-full w-full overflow-y-auto snap-y snap-mandatory [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
         {feed.map((item, idx) => (
@@ -171,7 +172,8 @@ export const ContentFeed = ({ initialSlug, feed }: ContentFeedProps) => {
       <div
         hidden
         dangerouslySetInnerHTML={{
-          __html: `<script>(function(){var c=document.getElementById("content-feed");if(!c)return;var t=c.querySelector('[data-slug=${JSON.stringify(initialSlug)}]');if(t)c.scrollTop=t.offsetTop;})();</script>`,
+          __html:
+            '<script>(function(){var c=document.getElementById("content-feed");if(!c)return;var s=c.getAttribute("data-initial-slug");var n=c.querySelectorAll("[data-slug]");for(var i=0;i<n.length;i++){if(n[i].getAttribute("data-slug")===s){c.scrollTop=n[i].offsetTop;return;}}})();</script>',
         }}
       />
       <ResponsiveAside

--- a/content/background-pixel-stars/background-pixel-stars.tsx
+++ b/content/background-pixel-stars/background-pixel-stars.tsx
@@ -332,13 +332,15 @@ export const BackgroundPixelStars = memo(
       animationFrameRef.current = requestAnimationFrame(animateCanvas);
 
       // Create shooting stars periodically
+      let shootingStarTimer: ReturnType<typeof setTimeout> | undefined;
+
       const createShootingStar = (): void => {
         const newStar = createNewShootingStar();
         shootingStarsRef.current = [...shootingStarsRef.current, newStar];
 
         // Set a random delay for creating the next star
         const randomDelay = Math.random() * 4000 + 2000; // 2-6 seconds
-        setTimeout(createShootingStar, randomDelay);
+        shootingStarTimer = setTimeout(createShootingStar, randomDelay);
       };
 
       // Create first shooting star
@@ -364,6 +366,7 @@ export const BackgroundPixelStars = memo(
           cancelAnimationFrame(animationFrameRef.current);
         }
         clearInterval(regenerationInterval);
+        if (shootingStarTimer !== undefined) clearTimeout(shootingStarTimer);
         window.removeEventListener("resize", handleResize);
       };
     }, [animateCanvas, createNewShootingStar, initBackgroundStars, regenerateBackgroundStars]);

--- a/content/background-shapes/package.json
+++ b/content/background-shapes/package.json
@@ -10,7 +10,6 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
   "dependencies": {
-    "motion": "^12.42.2",
     "react": "catalog:",
     "react-dom": "catalog:"
   },

--- a/content/card-stack/card-stack.tsx
+++ b/content/card-stack/card-stack.tsx
@@ -3,7 +3,7 @@ import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
 
 type CardStackProps = {
-  cards: { src: string; href: string }[];
+  cards: { src: string; href: string; alt: string }[];
   className?: string;
 };
 
@@ -150,7 +150,11 @@ export const CardStack = ({ cards }: CardStackProps) => {
             href={card.href}
             target="_blank"
           >
-            <img className="content h-full w-full rounded-[12px] object-cover" src={card.src} />
+            <img
+              alt={card.alt}
+              className="content h-full w-full rounded-[12px] object-cover"
+              src={card.src}
+            />
           </a>
         ))}
       </div>

--- a/content/card-stack/preview.tsx
+++ b/content/card-stack/preview.tsx
@@ -6,14 +6,14 @@ const rootUrl =
   "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/card-stack-1";
 
 const cards = [
-  { src: `${rootUrl}/uic.webp`, href: "https://uicapsule.com" },
-  { src: `${rootUrl}/kyh.webp`, href: "https://kyh.io" },
-  { src: `${rootUrl}/vg.webp`, href: "https://vibedgames.com" },
-  { src: `${rootUrl}/found.webp`, href: "https://founding.so" },
-  { src: `${rootUrl}/init.webp`, href: "https://init.kyh.io" },
-  { src: `${rootUrl}/tc.webp`, href: "https://tc.kyh.io" },
-  { src: `${rootUrl}/data.webp`, href: "https://dataembed.com`" },
-  { src: `${rootUrl}/ys.webp`, href: "https://yourssincerely.org" },
+  { src: `${rootUrl}/uic.webp`, href: "https://uicapsule.com", alt: "UI Capsule" },
+  { src: `${rootUrl}/kyh.webp`, href: "https://kyh.io", alt: "KYH" },
+  { src: `${rootUrl}/vg.webp`, href: "https://vibedgames.com", alt: "Vibed Games" },
+  { src: `${rootUrl}/found.webp`, href: "https://founding.so", alt: "Founding" },
+  { src: `${rootUrl}/init.webp`, href: "https://init.kyh.io", alt: "Init" },
+  { src: `${rootUrl}/tc.webp`, href: "https://tc.kyh.io", alt: "TC" },
+  { src: `${rootUrl}/data.webp`, href: "https://dataembed.com`", alt: "Data Embed" },
+  { src: `${rootUrl}/ys.webp`, href: "https://yourssincerely.org", alt: "Yours Sincerely" },
 ];
 
 const Preview = () => {

--- a/content/carousel-3d/package.json
+++ b/content/carousel-3d/package.json
@@ -10,7 +10,6 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
   "dependencies": {
-    "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/content/dynamic-island/ring.tsx
+++ b/content/dynamic-island/ring.tsx
@@ -20,22 +20,23 @@ export function Ring() {
   return (
     <motion.div
       initial={false}
+      layout
       className="relative flex h-7 items-center justify-between px-2.5"
-      animate={{ width: isSilent ? 148 : 128 }}
+      style={{ width: isSilent ? 148 : 128 }}
       transition={{ type: "spring", bounce: 0.5 }}
     >
       <AnimatePresence>
         {isSilent ? (
           <motion.div
-            initial={{ width: 0, opacity: 0, filter: "blur(4px)" }}
+            initial={{ scaleX: 0, opacity: 0, filter: "blur(4px)" }}
             animate={{
-              width: 40,
+              scaleX: 1,
               opacity: 1,
               filter: "blur(0px)",
             }}
-            exit={{ width: 0, opacity: 0, filter: "blur(4px)" }}
+            exit={{ scaleX: 0, opacity: 0, filter: "blur(4px)" }}
             transition={{ type: "spring", bounce: 0.35 }}
-            className="absolute left-[5px] h-[18px] w-10 rounded-full bg-[#FD4F30]"
+            className="absolute left-[5px] h-[18px] w-10 origin-left rounded-full bg-[#FD4F30]"
           />
         ) : null}
       </AnimatePresence>
@@ -63,13 +64,13 @@ export function Ring() {
         <div className="absolute inset-0">
           <div className="h-5 translate-x-[5.25px] -translate-y-[5px] rotate-[-40deg] overflow-hidden">
             <motion.div
-              animate={{ height: isSilent ? 16 : 0 }}
+              animate={{ scaleY: isSilent ? 1 : 0 }}
               transition={{
                 ease: "easeInOut",
                 duration: isSilent ? 0.125 : 0.05,
                 delay: isSilent ? 0.15 : 0,
               }}
-              className="w-fit rounded-full"
+              className="h-4 w-fit origin-top rounded-full"
             >
               <div className="flex h-full w-[3px] items-center justify-center rounded-full bg-[#FD4F30]">
                 <div className="h-full w-[0.75px] rounded-full bg-white" />

--- a/content/dynamic-island/timer.tsx
+++ b/content/dynamic-island/timer.tsx
@@ -7,6 +7,7 @@ export function Timer() {
   return (
     <div className="flex w-[284px] items-center gap-2 py-3 pr-5 pl-3.5">
       <motion.button
+        type="button"
         aria-label="Pause timer"
         onClick={() => setIsPaused((p) => !p)}
         whileTap={{ scale: 0.9 }}
@@ -45,6 +46,7 @@ export function Timer() {
         </AnimatePresence>
       </motion.button>
       <button
+        type="button"
         aria-label="Exit"
         className="flex h-10 w-10 items-center justify-center rounded-full bg-[#3C3D3C] text-white transition-colors hover:bg-[#4A4B4A]"
       >

--- a/content/emerald-template/_components/hero-example.tsx
+++ b/content/emerald-template/_components/hero-example.tsx
@@ -470,16 +470,18 @@ const Typewriter = ({
 
   useEffect(() => {
     let i = 0;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let cancelled = false;
     const splitBy = splitType === "letters" ? "" : " ";
     const splitText = text.split(splitBy);
 
     const write = () => {
-      if (!textContainerRef.current || finishedRef.current) return;
+      if (cancelled || !textContainerRef.current || finishedRef.current) return;
       if (i < splitText.length) {
         animatingRef.current = true;
         textContainerRef.current.innerHTML = splitText.slice(0, i + 1).join(splitBy);
         i++;
-        setTimeout(write, 25);
+        timeoutId = setTimeout(write, 25);
       } else {
         animatingRef.current = false;
         finishedRef.current = true;
@@ -489,12 +491,12 @@ const Typewriter = ({
     };
 
     const clear = () => {
-      if (!textContainerRef.current || !finishedRef.current) return;
+      if (cancelled || !textContainerRef.current || !finishedRef.current) return;
       if (i < splitText.length) {
         animatingRef.current = true;
         textContainerRef.current.innerHTML = splitText.slice(0, text.length - i).join(splitBy);
         i++;
-        setTimeout(clear, 5);
+        timeoutId = setTimeout(clear, 5);
       } else {
         animatingRef.current = false;
         finishedRef.current = false;
@@ -511,6 +513,12 @@ const Typewriter = ({
     } else {
       clear();
     }
+
+    return () => {
+      cancelled = true;
+      animatingRef.current = false;
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    };
   }, [textContainerRef, start, text, onTyped, onCleared, splitType]);
 
   return (

--- a/content/emerald-template/_components/hero-example.tsx
+++ b/content/emerald-template/_components/hero-example.tsx
@@ -479,7 +479,7 @@ const Typewriter = ({
       if (cancelled || !textContainerRef.current || finishedRef.current) return;
       if (i < splitText.length) {
         animatingRef.current = true;
-        textContainerRef.current.innerHTML = splitText.slice(0, i + 1).join(splitBy);
+        textContainerRef.current.textContent = splitText.slice(0, i + 1).join(splitBy);
         i++;
         timeoutId = setTimeout(write, 25);
       } else {
@@ -494,14 +494,14 @@ const Typewriter = ({
       if (cancelled || !textContainerRef.current || !finishedRef.current) return;
       if (i < splitText.length) {
         animatingRef.current = true;
-        textContainerRef.current.innerHTML = splitText.slice(0, text.length - i).join(splitBy);
+        textContainerRef.current.textContent = splitText.slice(0, text.length - i).join(splitBy);
         i++;
         timeoutId = setTimeout(clear, 5);
       } else {
         animatingRef.current = false;
         finishedRef.current = false;
         i = 0;
-        textContainerRef.current.innerHTML = "";
+        textContainerRef.current.textContent = "";
         onCleared?.();
       }
     };

--- a/content/emerald-template/package.json
+++ b/content/emerald-template/package.json
@@ -16,8 +16,7 @@
     "lucide-react": "^1.24.0",
     "motion": "^12.42.2",
     "react": "catalog:",
-    "react-dom": "catalog:",
-    "react-hook-form": "^7.81.0"
+    "react-dom": "catalog:"
   },
   "devDependencies": {
     "@types/react": "catalog:",

--- a/content/expanding-header-menu/expanding-header-menu.tsx
+++ b/content/expanding-header-menu/expanding-header-menu.tsx
@@ -27,7 +27,10 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
     <MotionConfig transition={{ duration: 0.5, type: "spring", bounce: 0 }}>
       <AnimatePresence initial={false}>
         {isOpen && (
-          <motion.div
+          <motion.button
+            type="button"
+            aria-label="Close menu"
+            tabIndex={-1}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -58,6 +61,8 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
                     />
                   </motion.div>
                   <motion.button
+                    type="button"
+                    aria-label="Close menu"
                     layoutId="wrapper-close-button"
                     className="absolute top-0 left-0 -z-10 flex h-8 w-8 items-center justify-center text-[#C7C9CD]"
                     onClick={() => setIsOpen(false)}
@@ -69,7 +74,11 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
                   <h2 className="text-left text-sm font-bold">Kai</h2>
                   <p className="flex items-center text-xs text-[#ABABB0]">3 tabs</p>
                 </motion.div>
-                <button className="ml-auto flex h-8 w-8 items-center justify-center">
+                <button
+                  type="button"
+                  aria-label="More options"
+                  className="ml-auto flex h-8 w-8 items-center justify-center"
+                >
                   <Ellipsis strokeWidth={1.5} size={20} />
                 </button>
               </header>
@@ -83,6 +92,8 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
           layoutId="wrapper"
           role="button"
           tabIndex={0}
+          aria-label="Open workspace menu"
+          aria-expanded={isOpen}
           className="relative grow cursor-pointer overflow-hidden bg-[#232429] p-0.5"
           style={{ borderRadius: 8 }}
           onClick={() => setIsOpen(true)}
@@ -118,9 +129,16 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
               </p>
             </motion.div>
           </div>
-          <WrapperMenu className="pointer-events-none absolute top-0 right-0 left-0 opacity-0" />
+          <WrapperMenu
+            inert
+            className="pointer-events-none absolute top-0 right-0 left-0 opacity-0"
+          />
         </motion.div>
-        <button className="flex h-8 w-8 items-center justify-center">
+        <button
+          type="button"
+          aria-label="Open audio controls"
+          className="flex h-8 w-8 items-center justify-center"
+        >
           <Headphones strokeWidth={1.7} size={20} />
         </button>
       </header>
@@ -128,38 +146,61 @@ export const HeaderMenu = ({ isOpen, setIsOpen }: HeaderMenuProps) => {
   );
 };
 
-const WrapperMenu = ({ className }: { className?: string }) => {
+const WrapperMenu = ({ className, inert = false }: { className?: string; inert?: boolean }) => {
   return (
     <AnimatePresence>
-      <motion.div layoutId="wrapper-menu" className={cn("mt-1 text-[#C7C9CD]", className)}>
+      <motion.div
+        layoutId="wrapper-menu"
+        aria-hidden={inert || undefined}
+        inert={inert}
+        className={cn("mt-1 text-[#C7C9CD]", className)}
+      >
         <motion.div layout className="mb-2 grid grid-cols-3 gap-2 px-3 text-white">
-          <button className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm">
+          <button
+            type="button"
+            className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm"
+          >
             <UserRoundPlus strokeWidth={1.5} size={16} />
             Add
           </button>
-          <button className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm">
+          <button
+            type="button"
+            className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm"
+          >
             <Star strokeWidth={1.5} size={16} />
             Move
           </button>
-          <button className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm">
+          <button
+            type="button"
+            className="flex h-9 items-center justify-center gap-1 rounded-lg border border-[#313538] px-1 text-sm"
+          >
             <Search strokeWidth={1.5} size={16} />
             Search
           </button>
         </motion.div>
         <motion.div layout className="flex flex-col px-1">
-          <button className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]">
+          <button
+            type="button"
+            className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]"
+          >
             <div className="flex h-8 w-8 items-center justify-center">
               <MessagesSquare strokeWidth={1.5} size={16} />
             </div>
             Messages
           </button>
-          <button className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]">
+          <button
+            type="button"
+            className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]"
+          >
             <div className="flex h-8 w-8 items-center justify-center">
               <FilePlus2 strokeWidth={1.5} size={16} />
             </div>
             Add canvas
           </button>
-          <button className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]">
+          <button
+            type="button"
+            className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]"
+          >
             <div className="flex h-8 w-8 items-center justify-center">
               <GalleryVerticalEnd strokeWidth={1.5} size={16} />
             </div>
@@ -170,14 +211,20 @@ const WrapperMenu = ({ className }: { className?: string }) => {
           <div className="h-px w-full bg-[#23272A]" />
         </div>
         <motion.div layout className="flex flex-col px-1">
-          <button className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]">
+          <button
+            type="button"
+            className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]"
+          >
             <div className="flex h-8 w-8 items-center justify-center">
               <User strokeWidth={1.5} size={16} />
             </div>
             <span className="inline-block grow">View Profile</span>
             <ChevronRight strokeWidth={1.5} size={16} />
           </button>
-          <button className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]">
+          <button
+            type="button"
+            className="flex h-8 items-center gap-1 rounded-lg px-1 text-start text-sm hover:bg-[#313538]"
+          >
             <div className="flex h-8 w-8 items-center justify-center">
               <Settings strokeWidth={1.5} size={16} />
             </div>

--- a/content/feed/preview.tsx
+++ b/content/feed/preview.tsx
@@ -80,7 +80,7 @@ const Preview = () => {
                 <img
                   className="absolute inset-0 h-full w-32 rounded-s-lg object-cover sm:w-48"
                   src="https://images.unsplash.com/photo-1661956600655-e772b2b97db4?q=80&w=560&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-                  alt="Blog Image"
+                  alt="Mailchimp broadcast studio interface"
                 />
                 <div className="ms-32 grow p-4 sm:ms-48">
                   <div className="flex min-h-24 flex-col justify-center">

--- a/content/filter-bar/_components/filter-selector.tsx
+++ b/content/filter-bar/_components/filter-selector.tsx
@@ -79,7 +79,10 @@ function __FilterSelector<TData>({
   }, [property]);
 
   useEffect(() => {
-    if (!open) setTimeout(() => setValue(""), 150);
+    if (open) return;
+
+    const timeoutId = setTimeout(() => setValue(""), 150);
+    return () => clearTimeout(timeoutId);
   }, [open]);
 
   const content = useMemo(
@@ -331,13 +334,12 @@ function __QuickSearchFilters<TData>({
   actions,
   strategy,
 }: QuickSearchFiltersProps<TData>) {
-  if (!search || search.trim().length < 2) return null;
-
-  // biome-ignore lint/correctness/useHookAtTopLevel: its okay
   const cols = useMemo(
     () => columns.filter((c) => isAnyOf<ColumnDataType>(c.type, ["option", "multiOption"])),
     [columns],
   );
+
+  if (!search || search.trim().length < 2) return null;
 
   return (
     <>

--- a/content/filter-bar/_components/filter-value.tsx
+++ b/content/filter-bar/_components/filter-value.tsx
@@ -112,7 +112,9 @@ export function useDebounceCallback<T extends (...args: any) => ReturnType<T>>(
 function useUnmount(func: () => void) {
   const funcRef = useRef(func);
 
-  funcRef.current = func;
+  useEffect(() => {
+    funcRef.current = func;
+  }, [func]);
 
   useEffect(
     () => () => {

--- a/content/gradient-orb/package.json
+++ b/content/gradient-orb/package.json
@@ -10,7 +10,6 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
   "dependencies": {
-    "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.1",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/content/infinite-grid/preview.tsx
+++ b/content/infinite-grid/preview.tsx
@@ -15,6 +15,7 @@ const Cell = ({ gridIndex }: GridItemConfig) => (
     }}
   >
     <img
+      alt=""
       className="pointer-events-none size-20"
       src={`https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/illustrations/blueprint/%20${(gridIndex % 100) + 1}.svg`}
     />

--- a/content/light-dark-toggle/preview.tsx
+++ b/content/light-dark-toggle/preview.tsx
@@ -12,6 +12,8 @@ const Preview = () => {
       className={`main flex h-dvh items-center justify-center ${isLight ? "bg-stone-300" : "bg-stone-900"}`}
     >
       <button
+        type="button"
+        aria-label={isLight ? "Switch to dark mode" : "Switch to light mode"}
         className={`grid size-12 place-items-center rounded-xl bg-gradient-to-t shadow-lg ${isLight ? "from-[#f8fafc] to-[#f1f5f9] text-stone-950" : "from-[#020617] to-[#0F172A] text-stone-50"}`}
         onClick={() => setIsLight(!isLight)}
       >

--- a/content/snail-timer/preview.tsx
+++ b/content/snail-timer/preview.tsx
@@ -12,7 +12,9 @@ const Preview = () => {
 
   return (
     <div className="flex h-screen items-center justify-center">
-      <button onClick={handleToggleStarted}>{started ? "Stop Timer" : "Start Countdown"}</button>
+      <button type="button" onClick={handleToggleStarted}>
+        {started ? "Stop Timer" : "Start Countdown"}
+      </button>
       <SnailTimer started={started} />
     </div>
   );

--- a/content/tooltip-grid/tooltip.css
+++ b/content/tooltip-grid/tooltip.css
@@ -24,7 +24,7 @@
   --fade-stop: 90%;
   --border-color: #334155;
 
-  position: absolute;
+  position: fixed;
   pointer-events: none;
   top: 0;
   mask-composite: exclude;
@@ -32,7 +32,7 @@
 
 .lineV {
   width: 1px;
-  height: 100%;
+  height: 100dvh;
 
   background: linear-gradient(
     to bottom,
@@ -50,7 +50,7 @@
 }
 
 .lineH {
-  width: 100%;
+  width: 100dvw;
   height: 1px;
 
   background: linear-gradient(

--- a/content/tooltip-grid/tooltip.tsx
+++ b/content/tooltip-grid/tooltip.tsx
@@ -311,15 +311,15 @@ const easeInOutQuint = (x: number) => {
 const TooltipLines = ({ context }: { context: ContextType }) => {
   const floatingEl = context?.elements.floating;
 
-  if (!floatingEl || !context.x || !context.y) return null;
+  if (!floatingEl || context.x == null || context.y == null) return null;
 
   return (
     <>
       <motion.div
         className={`${"line"} ${"lineH"}`}
-        initial={{ opacity: 0, top: -1 }}
-        animate={{ opacity: 1, top: context.y }}
-        exit={{ opacity: 0, top: -1 }}
+        initial={{ opacity: 0, y: -1 }}
+        animate={{ opacity: 1, y: context.y }}
+        exit={{ opacity: 0, y: -1 }}
         transition={{
           ease: easeInOutQuint,
           duration: 1,
@@ -327,9 +327,9 @@ const TooltipLines = ({ context }: { context: ContextType }) => {
       />
       <motion.div
         className={`${"line"} ${"lineH"}`}
-        initial={{ opacity: 0, top: "100dvh" }}
-        animate={{ opacity: 1, top: context.y + floatingEl.offsetHeight }}
-        exit={{ opacity: 0, top: "100dvh" }}
+        initial={{ opacity: 0, y: "100dvh" }}
+        animate={{ opacity: 1, y: context.y + floatingEl.offsetHeight }}
+        exit={{ opacity: 0, y: "100dvh" }}
         transition={{
           ease: easeInOutQuint,
           duration: 1,
@@ -337,10 +337,9 @@ const TooltipLines = ({ context }: { context: ContextType }) => {
       />
       <motion.div
         className={`${"line"} ${"lineV"}`}
-        style={{ height: document.documentElement.scrollHeight }}
-        initial={{ opacity: 0, left: -1 }}
-        animate={{ opacity: 1, left: context.x }}
-        exit={{ opacity: 0, left: -1 }}
+        initial={{ opacity: 0, x: -1 }}
+        animate={{ opacity: 1, x: context.x }}
+        exit={{ opacity: 0, x: -1 }}
         transition={{
           ease: easeInOutQuint,
           duration: 1,
@@ -348,10 +347,9 @@ const TooltipLines = ({ context }: { context: ContextType }) => {
       />
       <motion.div
         className={`${"line"} ${"lineV"}`}
-        style={{ height: document.documentElement.scrollHeight }}
-        initial={{ opacity: 0, left: "100dvw" }}
-        animate={{ opacity: 1, left: context.x + floatingEl.offsetWidth }}
-        exit={{ opacity: 0, left: "100dvw" }}
+        initial={{ opacity: 0, x: "100dvw" }}
+        animate={{ opacity: 1, x: context.x + floatingEl.offsetWidth }}
+        exit={{ opacity: 0, x: "100dvw" }}
         transition={{
           ease: easeInOutQuint,
           duration: 1,

--- a/content/tooltip-grid/tooltip.tsx
+++ b/content/tooltip-grid/tooltip.tsx
@@ -67,6 +67,7 @@ export const useTooltip = ({
   const setOpen = setControlledOpen ?? setUncontrolledOpen;
 
   const data = useFloating({
+    strategy: "fixed",
     placement,
     open,
     onOpenChange: (isOpen, event) => {

--- a/docs/quality/react-doctor.md
+++ b/docs/quality/react-doctor.md
@@ -1,0 +1,371 @@
+# React Doctor triage
+
+React Doctor 0.7.6. Baseline: 263 findings (43 errors, 220 warnings). Final: 203 findings (13 errors, 190 warnings). Net: 60 findings removed.
+
+The remaining 13 scanner errors are triaged: 10 isolated content packages cannot see the app-level reduced-motion provider, one cleanup report is a false positive, and two Socket reports are accepted supply-chain heuristics with no known vulnerability.
+
+## Verification
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm build`
+- React Doctor full and changed-scope scans
+- Browser QA on desktop and mobile for every changed preview
+- Reduced-motion media emulation
+- Console and page-error checks
+
+## Status meanings
+
+- **fixed**: code changed; targeted scan and acceptance surface passed.
+- **runtime fixed**: real runtime boundary fixed; package-isolation heuristic remains.
+- **accepted**: false positive or reviewed risk with explicit rationale.
+- **follow-up**: plausible issue; needs product/interaction-specific verification.
+- **deferred**: heuristic cleanup or optimization without evidence.
+
+## Baseline issue ledger
+
+### @repo/web
+
+- 001 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+- 002 · warning · `nextjs-missing-metadata` · `src/app/(frame)/preview-frame/[slug]/page.tsx:1` · **accepted** — preview-frame is iframe infrastructure, not an indexable product page
+- 003 · warning · `js-combine-iterations` · `src/app/(frame)/preview-frame/[slug]/page.tsx:16` · **deferred** — measure bundle/runtime impact before changing
+- 004 · warning · `js-combine-iterations` · `src/app/(main)/(app)/_components/filter-combo-box.tsx:227` · **deferred** — measure bundle/runtime impact before changing
+- 005 · warning · `use-lazy-motion` · `src/app/(main)/(app)/_components/signature.tsx:4` · **deferred** — measure bundle/runtime impact before changing
+- 006 · warning · `use-lazy-motion` · `src/app/(main)/(content)/_components/aside.tsx:29` · **deferred** — measure bundle/runtime impact before changing
+- 007 · warning · `anchor-has-content` · `src/app/(main)/(content)/_components/aside.tsx:235` · **accepted** — render-prop link receives visible Button children at runtime
+- 008 · warning · `no-static-element-interactions` · `src/app/(main)/(content)/_components/code-preview.tsx:243` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 009 · warning · `js-index-maps` · `src/app/(main)/(content)/_components/content-feed.tsx:71` · **deferred** — measure bundle/runtime impact before changing
+- 010 · warning · `unsafe-json-in-html` · `src/app/(main)/(content)/_components/content-feed.tsx:173` · **fixed** — verified in changed-scope scan
+- 011 · warning · `unsafe-json-in-html` · `src/app/(main)/(content)/_components/content-feed.tsx:174` · **fixed** — verified in changed-scope scan
+- 012 · warning · `server-sequential-independent-await` · `src/app/(main)/(content)/ui/[slug]/page.tsx:31` · **follow-up** — plausible defect; verify affected behavior before edit
+- 013 · warning · `use-lazy-motion` · `src/components/layout.tsx:47` · **deferred** — measure bundle/runtime impact before changing
+- 014 · warning · `no-multi-comp` · `src/components/layout.tsx:115` · **deferred** — separate public-API or component-boundary refactor
+- 015 · warning · `no-giant-component` · `src/components/layout.tsx:139` · **deferred** — separate public-API or component-boundary refactor
+- 016 · warning · `no-multi-comp` · `src/components/layout.tsx:139` · **deferred** — separate public-API or component-boundary refactor
+- 017 · warning · `no-chain-state-updates` · `src/components/layout.tsx:172` · **accepted** — React 19 batches these state updates; no measured extra render
+- 018 · warning · `no-chain-state-updates` · `src/components/layout.tsx:174` · **accepted** — React 19 batches these state updates; no measured extra render
+- 019 · warning · `js-combine-iterations` · `src/components/layout.tsx:180` · **deferred** — measure bundle/runtime impact before changing
+- 020 · warning · `js-combine-iterations` · `src/components/layout.tsx:197` · **deferred** — measure bundle/runtime impact before changing
+- 021 · warning · `prefer-module-scope-static-value` · `src/components/layout.tsx:368` · **deferred** — low-risk maintainability suggestion; separate cleanup
+- 022 · warning · `unused-export` · `src/components/layout.tsx:501` · **deferred** — separate public-API or component-boundary refactor
+- 023 · warning · `no-multi-comp` · `src/components/layout.tsx:501` · **deferred** — separate public-API or component-boundary refactor
+- 024 · warning · `control-has-associated-label` · `src/components/layout.tsx:724` · **accepted** — render-prop wrapper; rendered control receives visible content
+- 025 · warning · `no-multi-comp` · `src/components/layout.tsx:790` · **deferred** — separate public-API or component-boundary refactor
+- 026 · warning · `no-multi-comp` · `src/components/layout.tsx:825` · **deferred** — separate public-API or component-boundary refactor
+- 027 · warning · `no-multi-comp` · `src/components/layout.tsx:842` · **deferred** — separate public-API or component-boundary refactor
+- 028 · warning · `use-lazy-motion` · `src/components/media-reveal.tsx:5` · **deferred** — measure bundle/runtime impact before changing
+- 029 · warning · `iframe-missing-sandbox` · `src/components/media-reveal.tsx:142` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 030 · warning · `js-flatmap-filter` · `src/lib/content-data.ts:36` · **deferred** — measure bundle/runtime impact before changing
+- 031 · warning · `js-set-map-lookups` · `src/lib/content-data.ts:39` · **deferred** — measure bundle/runtime impact before changing
+- 032 · warning · `js-combine-iterations` · `src/lib/content/content-fs.ts:107` · **deferred** — measure bundle/runtime impact before changing
+- 033 · warning · `js-set-map-lookups` · `src/lib/content/content-fs.ts:146` · **deferred** — measure bundle/runtime impact before changing
+- 034 · warning · `unused-export` · `src/trpc/react.tsx:24` · **deferred** — separate public-API or component-boundary refactor
+- 035 · warning · `unused-export` · `src/trpc/react.tsx:24` · **deferred** — separate public-API or component-boundary refactor
+- 036 · warning · `unused-export` · `src/trpc/react.tsx:24` · **deferred** — separate public-API or component-boundary refactor
+
+### @repo/db
+
+- 037 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+
+### @repo/ui
+
+- 038 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+- 039 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+- 040 · error · `low-supply-chain-score` · `package.json:22` · **accepted** — reviewed: no known vulnerability, install hooks, runtime deps, or unlocked artifact
+- 041 · warning · `only-export-components` · `src/components/alert-dialog.tsx:195` · **deferred** — separate public-API or component-boundary refactor
+- 042 · warning · `prefer-module-scope-pure-function` · `src/components/alert-dialog.tsx:215` · **deferred** — low-risk maintainability suggestion; separate cleanup
+- 043 · warning · `only-export-components` · `src/components/badge.tsx:50` · **deferred** — separate public-API or component-boundary refactor
+- 044 · warning · `only-export-components` · `src/components/button.tsx:94` · **deferred** — separate public-API or component-boundary refactor
+- 045 · warning · `no-locale-format-in-render` · `src/components/calendar.tsx:159` · **follow-up** — plausible defect; verify affected behavior before edit
+- 046 · warning · `jsx-no-constructed-context-values` · `src/components/code-block.tsx:299` · **deferred** — needs profiling or bundle evidence
+- 047 · warning · `no-array-index-as-key` · `src/components/code-block.tsx:418` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 048 · warning · `dangerous-html-sink` · `src/components/code-block.tsx:495` · **accepted** — Shiki output is escaped trusted renderer output
+- 049 · warning · `no-array-index-as-key` · `src/components/field.tsx:192` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 050 · warning · `rendering-svg-precision` · `src/components/logo.tsx:14` · **deferred** — measure bundle/runtime impact before changing
+- 051 · warning · `use-lazy-motion` · `src/components/toast.tsx:5` · **deferred** — measure bundle/runtime impact before changing
+- 052 · warning · `jsx-no-constructed-context-values` · `src/components/tree.tsx:44` · **deferred** — needs profiling or bundle evidence
+- 053 · warning · `control-has-associated-label` · `src/components/tree.tsx:81` · **accepted** — render-prop wrapper; rendered control receives visible content
+- 054 · warning · `jsx-no-constructed-context-values` · `src/components/tree.tsx:104` · **deferred** — needs profiling or bundle evidence
+- 055 · error · `no-ref-current-in-render` · `src/hooks/use-controllable-state.ts:21` · **fixed** — verified in changed-scope scan
+- 056 · error · `no-ref-current-in-render` · `src/hooks/use-controllable-state.ts:23` · **fixed** — verified in changed-scope scan
+- 057 · error · `no-ref-current-in-render` · `src/hooks/use-controllable-state.ts:25` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/background-pixel-stars
+
+- 058 · warning · `no-giant-component` · `background-pixel-stars.tsx:65` · **deferred** — separate public-API or component-boundary refactor
+- 059 · warning · `js-combine-iterations` · `background-pixel-stars.tsx:229` · **deferred** — measure bundle/runtime impact before changing
+- 060 · warning · `js-combine-iterations` · `background-pixel-stars.tsx:249` · **deferred** — measure bundle/runtime impact before changing
+- 061 · error · `effect-needs-cleanup` · `background-pixel-stars.tsx:321` · **fixed** — timer cleanup added and route verified
+- 062 · warning · `prefer-use-effect-event` · `background-pixel-stars.tsx:369` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+
+### @uicapsule/background-shapes
+
+- 063 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+- 064 · error · `require-reduced-motion` · `package.json:0` · **fixed** — unused motion dependency removed
+- 065 · warning · `rendering-conditional-render` · `preview.tsx:19` · **follow-up** — plausible defect; verify affected behavior before edit
+
+### @uicapsule/card-stack
+
+- 066 · warning · `control-has-associated-label` · `card-stack.tsx:147` · **fixed** — control now has accessible name
+- 067 · error · `alt-text` · `card-stack.tsx:153` · **fixed** — verified in changed-scope scan
+- 068 · warning · `nextjs-no-img-element` · `card-stack.tsx:153` · **accepted** — portable content package; Next-only primitive would break copyability
+
+### @uicapsule/carousel-3d
+
+- 069 · warning · `no-giant-component` · `carousel-3d.tsx:83` · **deferred** — separate public-API or component-boundary refactor
+- 070 · warning · `exhaustive-deps` · `carousel-3d.tsx:201` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 071 · warning · `no-nested-component-definition` · `carousel-3d.tsx:333` · **follow-up** — plausible defect; verify affected behavior before edit
+- 072 · warning · `no-unstable-nested-components` · `carousel-3d.tsx:333` · **deferred** — needs profiling or bundle evidence
+- 073 · warning · `no-array-index-as-key` · `carousel-3d.tsx:447` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 074 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+
+### @uicapsule/dynamic-ai-composer
+
+- 075 · warning · `use-lazy-motion` · `dynamic-ai-composer.tsx:5` · **deferred** — measure bundle/runtime impact before changing
+- 076 · warning · `no-array-index-as-key` · `dynamic-ai-composer.tsx:280` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 077 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+
+### @uicapsule/dynamic-island
+
+- 078 · warning · `use-lazy-motion` · `dynamic-island.tsx:4` · **deferred** — measure bundle/runtime impact before changing
+- 079 · warning · `use-lazy-motion` · `expanded-widgets.tsx:17` · **deferred** — measure bundle/runtime impact before changing
+- 080 · warning · `only-export-components` · `expanded-widgets.tsx:26` · **deferred** — separate public-API or component-boundary refactor
+- 081 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 082 · warning · `use-lazy-motion` · `ring.tsx:2` · **deferred** — measure bundle/runtime impact before changing
+- 083 · error · `no-layout-property-animation` · `ring.tsx:24` · **fixed** — verified in changed-scope scan
+- 084 · error · `no-layout-property-animation` · `ring.tsx:30` · **fixed** — verified in changed-scope scan
+- 085 · error · `no-layout-property-animation` · `ring.tsx:32` · **fixed** — verified in changed-scope scan
+- 086 · error · `no-layout-property-animation` · `ring.tsx:36` · **fixed** — verified in changed-scope scan
+- 087 · warning · `rendering-svg-precision` · `ring.tsx:59` · **deferred** — measure bundle/runtime impact before changing
+- 088 · error · `no-layout-property-animation` · `ring.tsx:66` · **fixed** — verified in changed-scope scan
+- 089 · warning · `use-lazy-motion` · `timer.tsx:1` · **deferred** — measure bundle/runtime impact before changing
+- 090 · warning · `rendering-svg-precision` · `timer.tsx:28` · **deferred** — measure bundle/runtime impact before changing
+- 091 · warning · `button-has-type` · `timer.tsx:47` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/emerald-template
+
+- 092 · warning · `jsx-no-constructed-context-values` · `_components/chain-of-thought.tsx:53` · **deferred** — needs profiling or bundle evidence
+- 093 · warning · `prefer-module-scope-static-value` · `_components/chain-of-thought.tsx:102` · **deferred** — low-risk maintainability suggestion; separate cleanup
+- 094 · warning · `no-array-index-as-key` · `_components/features-section.tsx:93` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 095 · warning · `nextjs-no-a-element` · `_components/footer.tsx:17` · **accepted** — portable content package; Next-only primitive would break copyability
+- 096 · warning · `nextjs-no-a-element` · `_components/footer.tsx:20` · **accepted** — portable content package; Next-only primitive would break copyability
+- 097 · warning · `nextjs-no-a-element` · `_components/footer.tsx:26` · **accepted** — portable content package; Next-only primitive would break copyability
+- 098 · warning · `nextjs-no-a-element` · `_components/footer.tsx:29` · **accepted** — portable content package; Next-only primitive would break copyability
+- 099 · warning · `nextjs-no-a-element` · `_components/footer.tsx:32` · **accepted** — portable content package; Next-only primitive would break copyability
+- 100 · warning · `nextjs-no-a-element` · `_components/footer.tsx:38` · **accepted** — portable content package; Next-only primitive would break copyability
+- 101 · warning · `nextjs-no-a-element` · `_components/footer.tsx:41` · **accepted** — portable content package; Next-only primitive would break copyability
+- 102 · warning · `unused-export` · `_components/footer.tsx:97` · **deferred** — separate public-API or component-boundary refactor
+- 103 · error · `effect-needs-cleanup` · `_components/header.tsx:17` · **accepted** — false positive; effect returns Motion unsubscribe
+- 104 · warning · `nextjs-no-a-element` · `_components/header.tsx:32` · **accepted** — portable content package; Next-only primitive would break copyability
+- 105 · warning · `nextjs-no-a-element` · `_components/header.tsx:39` · **accepted** — portable content package; Next-only primitive would break copyability
+- 106 · warning · `nextjs-no-a-element` · `_components/header.tsx:42` · **accepted** — portable content package; Next-only primitive would break copyability
+- 107 · warning · `nextjs-no-a-element` · `_components/header.tsx:47` · **accepted** — portable content package; Next-only primitive would break copyability
+- 108 · warning · `use-lazy-motion` · `_components/hero-example.tsx:16` · **deferred** — measure bundle/runtime impact before changing
+- 109 · warning · `unused-export` · `_components/hero-example.tsx:275` · **deferred** — separate public-API or component-boundary refactor
+- 110 · warning · `prefer-useReducer` · `_components/hero-example.tsx:275` · **deferred** — separate public-API or component-boundary refactor
+- 111 · warning · `rerender-state-only-in-handlers` · `_components/hero-example.tsx:285` · **deferred** — needs profiling or bundle evidence
+- 112 · warning · `async-await-in-loop` · `_components/hero-example.tsx:329` · **accepted** — intentional sequential demo animation
+- 113 · warning · `no-array-index-as-key` · `_components/hero-example.tsx:377` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 114 · error · `effect-needs-cleanup` · `_components/hero-example.tsx:471` · **fixed** — timer cleanup added and route verified
+- 115 · warning · `dangerous-html-sink` · `_components/hero-example.tsx:480` · **fixed** — typewriter now writes textContent
+- 116 · warning · `dangerous-html-sink` · `_components/hero-example.tsx:495` · **fixed** — typewriter now writes textContent
+- 117 · warning · `prefer-use-effect-event` · `_components/hero-example.tsx:514` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 118 · warning · `prefer-use-effect-event` · `_components/hero-example.tsx:514` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 119 · warning · `anchor-is-valid` · `_components/hero-section.tsx:40` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 120 · warning · `use-lazy-motion` · `_components/highlight-card.tsx:5` · **deferred** — measure bundle/runtime impact before changing
+- 121 · warning · `no-array-index-as-key` · `_components/integrations-section.tsx:54` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 122 · warning · `rendering-svg-precision` · `_components/logo.tsx:14` · **deferred** — measure bundle/runtime impact before changing
+- 123 · warning · `use-lazy-motion` · `_components/workflow-section.tsx:13` · **deferred** — measure bundle/runtime impact before changing
+- 124 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+- 125 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 126 · error · `low-supply-chain-score` · `package.json:13` · **accepted** — reviewed: no known vulnerability, install hooks, runtime deps, or unlocked artifact
+
+### @uicapsule/expanding-header-menu
+
+- 127 · warning · `use-lazy-motion` · `expanding-header-menu.tsx:18` · **deferred** — measure bundle/runtime impact before changing
+- 128 · warning · `click-events-have-key-events` · `expanding-header-menu.tsx:30` · **fixed** — verified in changed-scope scan
+- 129 · warning · `nextjs-no-img-element` · `expanding-header-menu.tsx:54` · **accepted** — portable content package; Next-only primitive would break copyability
+- 130 · warning · `control-has-associated-label` · `expanding-header-menu.tsx:72` · **fixed** — control now has accessible name
+- 131 · warning · `button-has-type` · `expanding-header-menu.tsx:72` · **fixed** — verified in changed-scope scan
+- 132 · warning · `nextjs-no-img-element` · `expanding-header-menu.tsx:99` · **accepted** — portable content package; Next-only primitive would break copyability
+- 133 · warning · `control-has-associated-label` · `expanding-header-menu.tsx:123` · **fixed** — control now has accessible name
+- 134 · warning · `button-has-type` · `expanding-header-menu.tsx:123` · **fixed** — verified in changed-scope scan
+- 135 · warning · `button-has-type` · `expanding-header-menu.tsx:136` · **fixed** — verified in changed-scope scan
+- 136 · warning · `button-has-type` · `expanding-header-menu.tsx:140` · **fixed** — verified in changed-scope scan
+- 137 · warning · `button-has-type` · `expanding-header-menu.tsx:144` · **fixed** — verified in changed-scope scan
+- 138 · warning · `button-has-type` · `expanding-header-menu.tsx:150` · **fixed** — verified in changed-scope scan
+- 139 · warning · `button-has-type` · `expanding-header-menu.tsx:156` · **fixed** — verified in changed-scope scan
+- 140 · warning · `button-has-type` · `expanding-header-menu.tsx:162` · **fixed** — verified in changed-scope scan
+- 141 · warning · `button-has-type` · `expanding-header-menu.tsx:173` · **fixed** — verified in changed-scope scan
+- 142 · warning · `button-has-type` · `expanding-header-menu.tsx:180` · **fixed** — verified in changed-scope scan
+- 143 · warning · `nextjs-no-img-element` · `preview.tsx:17` · **accepted** — portable content package; Next-only primitive would break copyability
+
+### @uicapsule/feed
+
+- 144 · warning · `nextjs-no-img-element` · `preview.tsx:80` · **accepted** — portable content package; Next-only primitive would break copyability
+- 145 · warning · `img-redundant-alt` · `preview.tsx:83` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/filter-bar
+
+- 146 · warning · `no-barrel-import` · `_components/active-filters.tsx:14` · **deferred** — measure bundle/runtime impact before changing
+- 147 · warning · `unused-export` · `_components/active-filters.tsx:82` · **deferred** — separate public-API or component-boundary refactor
+- 148 · warning · `no-barrel-import` · `_components/filter-operator.tsx:20` · **deferred** — measure bundle/runtime impact before changing
+- 149 · warning · `unused-export` · `_components/filter-operator.tsx:99` · **deferred** — separate public-API or component-boundary refactor
+- 150 · warning · `unused-export` · `_components/filter-operator.tsx:121` · **deferred** — separate public-API or component-boundary refactor
+- 151 · warning · `unused-export` · `_components/filter-operator.tsx:277` · **deferred** — separate public-API or component-boundary refactor
+- 152 · warning · `no-barrel-import` · `_components/filter-selector.tsx:37` · **deferred** — measure bundle/runtime impact before changing
+- 153 · warning · `no-chain-state-updates` · `_components/filter-selector.tsx:77` · **accepted** — React 19 batches these state updates; no measured extra render
+- 154 · error · `effect-needs-cleanup` · `_components/filter-selector.tsx:81` · **fixed** — timer cleanup added and route verified
+- 155 · warning · `no-event-handler` · `_components/filter-selector.tsx:81` · **fixed** — verified in changed-scope scan
+- 156 · warning · `unused-export` · `_components/filter-selector.tsx:212` · **deferred** — separate public-API or component-boundary refactor
+- 157 · warning · `unused-export` · `_components/filter-selector.tsx:325` · **deferred** — separate public-API or component-boundary refactor
+- 158 · error · `rules-of-hooks` · `_components/filter-selector.tsx:337` · **fixed** — verified in changed-scope scan
+- 159 · warning · `js-set-map-lookups` · `_components/filter-selector.tsx:356` · **deferred** — measure bundle/runtime impact before changing
+- 160 · warning · `no-barrel-import` · `_components/filter-value.tsx:49` · **deferred** — measure bundle/runtime impact before changing
+- 161 · error · `no-ref-current-in-render` · `_components/filter-value.tsx:115` · **fixed** — verified in changed-scope scan
+- 162 · warning · `unused-export` · `_components/filter-value.tsx:252` · **deferred** — separate public-API or component-boundary refactor
+- 163 · warning · `exhaustive-deps` · `_components/filter-value.tsx:271` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 164 · warning · `unused-export` · `_components/filter-value.tsx:350` · **deferred** — separate public-API or component-boundary refactor
+- 165 · warning · `unused-export` · `_components/filter-value.tsx:411` · **deferred** — separate public-API or component-boundary refactor
+- 166 · warning · `js-set-map-lookups` · `_components/filter-value.tsx:417` · **deferred** — measure bundle/runtime impact before changing
+- 167 · warning · `unused-export` · `_components/filter-value.tsx:456` · **deferred** — separate public-API or component-boundary refactor
+- 168 · warning · `js-set-map-lookups` · `_components/filter-value.tsx:462` · **deferred** — measure bundle/runtime impact before changing
+- 169 · warning · `unused-export` · `_components/filter-value.tsx:514` · **deferred** — separate public-API or component-boundary refactor
+- 170 · warning · `unused-export` · `_components/filter-value.tsx:537` · **deferred** — separate public-API or component-boundary refactor
+- 171 · warning · `unused-export` · `_components/filter-value.tsx:551` · **deferred** — separate public-API or component-boundary refactor
+- 172 · warning · `unused-export` · `_components/filter-value.tsx:573` · **deferred** — separate public-API or component-boundary refactor
+- 173 · warning · `unused-export` · `_components/filter-value.tsx:683` · **deferred** — separate public-API or component-boundary refactor
+- 174 · warning · `exhaustive-deps` · `_components/filter-value.tsx:689` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 175 · warning · `js-set-map-lookups` · `_components/filter-value.tsx:695` · **deferred** — measure bundle/runtime impact before changing
+- 176 · warning · `unused-export` · `_components/filter-value.tsx:742` · **deferred** — separate public-API or component-boundary refactor
+- 177 · warning · `exhaustive-deps` · `_components/filter-value.tsx:748` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 178 · warning · `js-set-map-lookups` · `_components/filter-value.tsx:754` · **deferred** — measure bundle/runtime impact before changing
+- 179 · warning · `unused-export` · `_components/filter-value.tsx:801` · **deferred** — separate public-API or component-boundary refactor
+- 180 · warning · `unused-export` · `_components/filter-value.tsx:843` · **deferred** — separate public-API or component-boundary refactor
+- 181 · warning · `unused-export` · `_components/filter-value.tsx:870` · **deferred** — separate public-API or component-boundary refactor
+- 182 · warning · `exhaustive-deps` · `_components/filter-value.tsx:943` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 183 · warning · `unused-export` · `_components/filter-value.tsx:1022` · **deferred** — separate public-API or component-boundary refactor
+- 184 · warning · `js-combine-iterations` · `filter-package/core/columns/column-data-service.ts:51` · **deferred** — measure bundle/runtime impact before changing
+- 185 · warning · `js-combine-iterations` · `filter-package/core/columns/column-data-service.ts:120` · **deferred** — measure bundle/runtime impact before changing
+- 186 · warning · `js-combine-iterations` · `filter-package/core/columns/column-data-service.ts:216` · **deferred** — measure bundle/runtime impact before changing
+- 187 · warning · `no-barrel-import` · `filter-package/hooks/use-data-table-filters.ts:22` · **deferred** — measure bundle/runtime impact before changing
+- 188 · warning · `exhaustive-deps` · `filter-package/hooks/use-data-table-filters.ts:89` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 189 · warning · `unused-file` · `filter-package/integrations/tanstack-table/filter-fns.ts:0` · **deferred** — separate public-API or component-boundary refactor
+- 190 · warning · `unused-file` · `filter-package/integrations/tanstack-table/index.ts:0` · **deferred** — separate public-API or component-boundary refactor
+- 191 · warning · `js-index-maps` · `filter-package/integrations/tanstack-table/index.ts:17` · **deferred** — measure bundle/runtime impact before changing
+- 192 · warning · `js-set-map-lookups` · `filter-package/lib/array.ts:4` · **deferred** — measure bundle/runtime impact before changing
+- 193 · warning · `unused-export` · `filter-package/lib/array.ts:129` · **deferred** — separate public-API or component-boundary refactor
+- 194 · warning · `js-set-map-lookups` · `filter-package/lib/array.ts:138` · **deferred** — measure bundle/runtime impact before changing
+- 195 · warning · `unused-export` · `filter-package/lib/array.ts:175` · **deferred** — separate public-API or component-boundary refactor
+- 196 · warning · `unused-export` · `filter-package/lib/array.ts:246` · **deferred** — separate public-API or component-boundary refactor
+- 197 · warning · `unused-export` · `filter-package/lib/filter-fns.ts:217` · **deferred** — separate public-API or component-boundary refactor
+- 198 · warning · `unused-export` · `filter-package/lib/helpers.ts:183` · **deferred** — separate public-API or component-boundary refactor
+- 199 · warning · `unused-export` · `filter-package/lib/order-fns.ts:206` · **deferred** — separate public-API or component-boundary refactor
+- 200 · warning · `no-barrel-import` · `filters.tsx:12` · **deferred** — measure bundle/runtime impact before changing
+- 201 · warning · `no-barrel-import` · `preview.tsx:7` · **deferred** — measure bundle/runtime impact before changing
+
+### @uicapsule/geometric-orb
+
+- 202 · warning · `rerender-lazy-ref-init` · `geometric-orb.tsx:72` · **deferred** — needs profiling or bundle evidence
+
+### @uicapsule/gradient-orb
+
+- 203 · warning · `unused-dependency` · `package.json:0` · **fixed** — unused manifest entry and lock edge removed
+
+### @uicapsule/infinite-grid
+
+- 204 · warning · `no-static-element-interactions` · `infinite-grid.tsx:456` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 205 · warning · `no-permanent-will-change` · `infinite-grid.tsx:479` · **deferred** — measure bundle/runtime impact before changing
+- 206 · warning · `no-permanent-will-change` · `infinite-grid.tsx:500` · **deferred** — measure bundle/runtime impact before changing
+- 207 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 208 · warning · `use-lazy-motion` · `preview.tsx:3` · **deferred** — measure bundle/runtime impact before changing
+- 209 · warning · `no-scale-from-zero` · `preview.tsx:10` · **deferred** — visual style choice; needs product-motion review
+- 210 · error · `alt-text` · `preview.tsx:17` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/ios-volume-slider
+
+- 211 · warning · `use-lazy-motion` · `ios-volume-slider.tsx:3` · **deferred** — measure bundle/runtime impact before changing
+- 212 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+
+### @uicapsule/light-dark-toggle
+
+- 213 · warning · `use-lazy-motion` · `light-dark-toggle.tsx:1` · **deferred** — measure bundle/runtime impact before changing
+- 214 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 215 · warning · `button-has-type` · `preview.tsx:14` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/like-button
+
+- 216 · warning · `use-lazy-motion` · `like-button.tsx:5` · **deferred** — measure bundle/runtime impact before changing
+- 217 · warning · `no-scale-from-zero` · `like-button.tsx:24` · **deferred** — visual style choice; needs product-motion review
+- 218 · warning · `prefer-module-scope-static-value` · `like-button.tsx:45` · **deferred** — low-risk maintainability suggestion; separate cleanup
+- 219 · warning · `no-array-index-as-key` · `like-button.tsx:66` · **deferred** — mostly static decorative lists; change only with stable domain key
+- 220 · warning · `rerender-functional-setstate` · `like-button.tsx:163` · **deferred** — needs profiling or bundle evidence
+- 221 · warning · `rerender-functional-setstate` · `like-button.tsx:166` · **deferred** — needs profiling or bundle evidence
+- 222 · warning · `no-scale-from-zero` · `like-button.tsx:185` · **deferred** — visual style choice; needs product-motion review
+- 223 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+
+### @uicapsule/radial-slider
+
+- 224 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 225 · warning · `use-lazy-motion` · `radial-slider.tsx:3` · **deferred** — measure bundle/runtime impact before changing
+
+### @uicapsule/sidebar
+
+- 226 · warning · `unused-file` · `resizable-demo.tsx:0` · **deferred** — separate public-API or component-boundary refactor
+- 227 · warning · `nextjs-no-img-element` · `sidebar.tsx:138` · **accepted** — portable content package; Next-only primitive would break copyability
+- 228 · warning · `no-static-element-interactions` · `sidebar.tsx:239` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+
+### @uicapsule/snail-timer
+
+- 229 · warning · `button-has-type` · `preview.tsx:15` · **fixed** — verified in changed-scope scan
+- 230 · warning · `rendering-svg-precision` · `snail-timer.tsx:65` · **deferred** — measure bundle/runtime impact before changing
+
+### @uicapsule/spinner-pixel-grid
+
+- 231 · warning · `no-match-media-in-state-initializer` · `spinner-pixel-grid.tsx:222` · **follow-up** — plausible defect; verify affected behavior before edit
+- 232 · warning · `only-export-components` · `spinner-pixel-grid.tsx:305` · **deferred** — separate public-API or component-boundary refactor
+- 233 · warning · `only-export-components` · `spinner-pixel-grid.tsx:305` · **deferred** — separate public-API or component-boundary refactor
+
+### @uicapsule/spreadsheet
+
+- 234 · warning · `no-static-element-interactions` · `components/memoized-table-body.tsx:60` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 235 · warning · `no-static-element-interactions` · `components/memoized-table-body.tsx:77` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 236 · warning · `no-static-element-interactions` · `components/resize-handle.tsx:88` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 237 · warning · `no-static-element-interactions` · `components/spreadsheet.tsx:132` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 238 · warning · `no-static-element-interactions` · `components/spreadsheet.tsx:155` · **follow-up** — needs destination, keyboard model, or iframe trust contract
+- 239 · warning · `exhaustive-deps` · `lib/use-spreadsheet-handlers.ts:280` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+
+### @uicapsule/tooltip-grid
+
+- 240 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 241 · warning · `use-lazy-motion` · `tooltip.tsx:35` · **deferred** — measure bundle/runtime impact before changing
+- 242 · warning · `no-chain-state-updates` · `tooltip.tsx:172` · **accepted** — React 19 batches these state updates; no measured extra render
+- 243 · warning · `exhaustive-deps` · `tooltip.tsx:174` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 244 · warning · `exhaustive-deps` · `tooltip.tsx:184` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+- 245 · error · `no-layout-property-animation` · `tooltip.tsx:320` · **fixed** — verified in changed-scope scan
+- 246 · error · `no-layout-property-animation` · `tooltip.tsx:321` · **fixed** — verified in changed-scope scan
+- 247 · error · `no-layout-property-animation` · `tooltip.tsx:322` · **fixed** — verified in changed-scope scan
+- 248 · error · `no-layout-property-animation` · `tooltip.tsx:330` · **fixed** — verified in changed-scope scan
+- 249 · error · `no-layout-property-animation` · `tooltip.tsx:331` · **fixed** — verified in changed-scope scan
+- 250 · error · `no-layout-property-animation` · `tooltip.tsx:332` · **fixed** — verified in changed-scope scan
+- 251 · error · `no-unguarded-browser-global-in-render-or-hook-init` · `tooltip.tsx:340` · **fixed** — verified in changed-scope scan
+- 252 · error · `no-layout-property-animation` · `tooltip.tsx:341` · **fixed** — verified in changed-scope scan
+- 253 · error · `no-layout-property-animation` · `tooltip.tsx:342` · **fixed** — verified in changed-scope scan
+- 254 · error · `no-layout-property-animation` · `tooltip.tsx:343` · **fixed** — verified in changed-scope scan
+- 255 · error · `no-unguarded-browser-global-in-render-or-hook-init` · `tooltip.tsx:351` · **fixed** — verified in changed-scope scan
+- 256 · error · `no-layout-property-animation` · `tooltip.tsx:352` · **fixed** — verified in changed-scope scan
+- 257 · error · `no-layout-property-animation` · `tooltip.tsx:353` · **fixed** — verified in changed-scope scan
+- 258 · error · `no-layout-property-animation` · `tooltip.tsx:354` · **fixed** — verified in changed-scope scan
+
+### @uicapsule/voice-dictator
+
+- 259 · error · `require-reduced-motion` · `package.json:0` · **runtime fixed** — frame MotionProvider honors OS setting; isolated-package scan cannot see boundary
+- 260 · warning · `use-lazy-motion` · `voice-dictator.tsx:4` · **deferred** — measure bundle/runtime impact before changing
+- 261 · warning · `no-giant-component` · `voice-dictator.tsx:47` · **deferred** — separate public-API or component-boundary refactor
+- 262 · warning · `prefer-use-effect-event` · `voice-dictator.tsx:353` · **follow-up** — inspect callback semantics; avoid mechanical dependency edits
+
+### @uicapsule/wireframe-orb
+
+- 263 · warning · `unused-dependency` · `package.json:0` · **accepted** — required peer of @react-three/postprocessing
+
+

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,8 +21,7 @@
     "@libsql/client": "^0.17.4",
     "drizzle-orm": "^0.45.2",
     "next": "catalog:",
-    "react": "catalog:",
-    "zod": "catalog:"
+    "react": "catalog:"
   },
   "devDependencies": {
     "@kyh/tsconfig": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@base-ui/react": "catalog:",
     "@headless-tree/core": "^1.7.0",
-    "@headless-tree/react": "^1.7.0",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "@shikijs/transformers": "^4.3.1",
     "class-variance-authority": "^0.7.1",
@@ -27,7 +26,6 @@
     "date-fns": "^4.4.0",
     "lucide-react": "^1.24.0",
     "motion": "^12.42.2",
-    "next-themes": "^0.4.6",
     "react-day-picker": "^10.0.1",
     "shadcn": "^4.13.0",
     "shiki": "^4.3.1",

--- a/packages/ui/src/hooks/use-controllable-state.ts
+++ b/packages/ui/src/hooks/use-controllable-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 type UseControllableStateParams<T> = {
   prop?: T | undefined;
@@ -6,39 +6,29 @@ type UseControllableStateParams<T> = {
   onChange?: ((state: T) => void) | undefined;
 };
 
-type SetStateFn<T> = (prev: T) => T;
-
 export const useControllableState = <T>({
   prop,
   defaultProp,
   onChange,
-}: UseControllableStateParams<T>): [T, (next: T | SetStateFn<T>) => void] => {
+}: UseControllableStateParams<T>): [T, (next: T) => void] => {
   const [uncontrolled, setUncontrolled] = useState(defaultProp);
   const isControlled = prop !== undefined;
   const value = isControlled ? prop : uncontrolled;
 
-  const valueRef = useRef(value);
-  valueRef.current = value;
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
-  const isControlledRef = useRef(isControlled);
-  isControlledRef.current = isControlled;
+  const setValue = useCallback(
+    (next: T) => {
+      if (isControlled) {
+        if (next !== value) onChange?.(next);
+        return;
+      }
 
-  const setValue = useCallback((next: T | SetStateFn<T>) => {
-    const resolve = (prev: T) =>
-      typeof next === "function" ? (next as SetStateFn<T>)(prev) : next;
-
-    if (isControlledRef.current) {
-      const resolved = resolve(valueRef.current);
-      if (resolved !== valueRef.current) onChangeRef.current?.(resolved);
-    } else {
-      setUncontrolled((prev) => {
-        const resolved = resolve(prev);
-        if (resolved !== prev) onChangeRef.current?.(resolved);
-        return resolved;
+      setUncontrolled((previous) => {
+        if (next !== previous) onChange?.(next);
+        return next;
       });
-    }
-  }, []);
+    },
+    [isControlled, onChange, value],
+  );
 
   return [value, setValue];
 };

--- a/packages/ui/src/hooks/use-controllable-state.ts
+++ b/packages/ui/src/hooks/use-controllable-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 type UseControllableStateParams<T> = {
   prop?: T | undefined;
@@ -6,29 +6,35 @@ type UseControllableStateParams<T> = {
   onChange?: ((state: T) => void) | undefined;
 };
 
+/** Direct values only. This keeps callable values unambiguous. */
+type SetValue<T> = (next: T) => void;
+
 export const useControllableState = <T>({
   prop,
   defaultProp,
   onChange,
-}: UseControllableStateParams<T>): [T, (next: T) => void] => {
+}: UseControllableStateParams<T>): [T, SetValue<T>] => {
   const [uncontrolled, setUncontrolled] = useState(defaultProp);
   const isControlled = prop !== undefined;
   const value = isControlled ? prop : uncontrolled;
+  const currentRef = useRef({ prop, onChange });
 
-  const setValue = useCallback(
-    (next: T) => {
-      if (prop !== undefined) {
-        if (next !== prop) onChange?.(next);
-        return;
-      }
+  useLayoutEffect(() => {
+    currentRef.current = { prop, onChange };
+  }, [onChange, prop]);
 
-      setUncontrolled((previous) => {
-        if (next !== previous) onChange?.(next);
-        return next;
-      });
-    },
-    [onChange, prop],
-  );
+  const setValue = useCallback((next: T) => {
+    const current = currentRef.current;
+    if (current.prop !== undefined) {
+      if (next !== current.prop) current.onChange?.(next);
+      return;
+    }
+
+    setUncontrolled((previous) => {
+      if (next !== previous) current.onChange?.(next);
+      return next;
+    });
+  }, []);
 
   return [value, setValue];
 };

--- a/packages/ui/src/hooks/use-controllable-state.ts
+++ b/packages/ui/src/hooks/use-controllable-state.ts
@@ -17,8 +17,8 @@ export const useControllableState = <T>({
 
   const setValue = useCallback(
     (next: T) => {
-      if (isControlled) {
-        if (next !== value) onChange?.(next);
+      if (prop !== undefined) {
+        if (next !== prop) onChange?.(next);
         return;
       }
 
@@ -27,7 +27,7 @@ export const useControllableState = <T>({
         return next;
       });
     },
-    [isControlled, onChange, value],
+    [onChange, prop],
   );
 
   return [value, setValue];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ importers:
       superjson:
         specifier: 'catalog:'
         version: 2.2.6
-      three:
-        specifier: ^0.185.1
-        version: 0.185.1
       web-haptics:
         specifier: ^0.0.6
         version: 0.0.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -280,9 +277,6 @@ importers:
 
   content/carousel-3d:
     dependencies:
-      '@react-three/drei':
-        specifier: ^10.7.7
-        version: 10.7.7(c228a5ce859ca7b00353857113b6e4a6)
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.17)(expo-asset@12.0.12(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(expo-file-system@19.0.21(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)))(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(three@0.185.1)
@@ -376,9 +370,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
-      react-hook-form:
-        specifier: ^7.81.0
-        version: 7.81.0(react@19.2.7)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -498,9 +489,6 @@ importers:
 
   content/gradient-orb:
     dependencies:
-      '@react-three/drei':
-        specifier: ^10.7.7
-        version: 10.7.7(c228a5ce859ca7b00353857113b6e4a6)
       '@react-three/fiber':
         specifier: ^9.6.1
         version: 9.6.1(@types/react@19.2.17)(expo-asset@12.0.12(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(expo-file-system@19.0.21(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)))(expo@54.0.31(@babel/core@7.29.7)(graphql@16.14.0)(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react-native@0.83.1(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(three@0.185.1)
@@ -897,9 +885,6 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.7
-      zod:
-        specifier: 'catalog:'
-        version: 4.4.3
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -922,9 +907,6 @@ importers:
       '@headless-tree/core':
         specifier: ^1.7.0
         version: 1.7.0
-      '@headless-tree/react':
-        specifier: ^1.7.0
-        version: 1.7.0(@headless-tree/core@1.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@icons-pack/react-simple-icons':
         specifier: ^13.13.0
         version: 13.13.0(react@19.2.7)
@@ -949,9 +931,6 @@ importers:
       motion:
         specifier: ^12.42.2
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next-themes:
-        specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,9 +242,6 @@ importers:
 
   content/background-shapes:
     dependencies:
-      motion:
-        specifier: ^12.42.2
-        version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 'catalog:'
         version: 19.2.7


### PR DESCRIPTION
## Outcome

React Doctor 0.7.6: 263 → 203 findings.

- Errors: 43 → 13
- Warnings: 220 → 190
- Removed: 60

All 263 baseline findings are individually triaged in [`docs/quality/react-doctor.md`](https://github.com/kyh/uicapsule/blob/kyh/react-doctor-triage/docs/quality/react-doctor.md).

## Verified stacks

- [x] Hook order and render-time ref mutation
- [x] Timer cleanup
- [x] Image alt text
- [x] Inline-script and text rendering hardening
- [x] Preview reduced-motion boundary
- [x] Tooltip SSR and transform animation
- [x] Dynamic Island transform animation
- [x] Control labels, button types, hidden focus state
- [x] Unused dependency removal

## Remaining scanner errors

- 10 reduced-motion reports: runtime fixed by frame `MotionProvider`; isolated package scans cannot see the app boundary.
- 1 effect-cleanup report: false positive; effect returns Motion unsubscribe.
- 2 Socket score reports: accepted after dependency review. No known vulnerability, install hooks, runtime dependencies, or unlocked artifact.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Full and changed-scope React Doctor scans
- Desktop/mobile browser QA
- Reduced-motion emulation
- Console/page-error checks

## Review focus

- `useControllableState` setter contract
- Preview-frame provider boundary
- Tooltip guide geometry
- Dynamic Island ring transitions
