### PR TITLE
fix: backport init template security + cleanup fixes

### DIFF
--- a/apps/web/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/web/src/app/api/trpc/[trpc]/route.ts
@@ -2,31 +2,12 @@ import type { NextRequest } from "next/server";
 import { appRouter, createTRPCContext } from "@repo/api";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 
-// export const runtime = "edge";
-
-/**
- * Configure basic CORS headers
- * You should extend this to match your needs
- */
-const setCorsHeaders = (res: Response) => {
-  res.headers.set("Access-Control-Allow-Origin", "*");
-  res.headers.set("Access-Control-Request-Method", "*");
-  res.headers.set("Access-Control-Allow-Methods", "OPTIONS, GET, POST");
-  res.headers.set("Access-Control-Allow-Headers", "*");
-};
-
-export const OPTIONS = () => {
-  const response = new Response(null, {
-    status: 204,
-  });
-
-  setCorsHeaders(response);
-
-  return response;
-};
-
-const handler = async (req: NextRequest) => {
-  const response = await fetchRequestHandler({
+// No CORS headers: every client reaches this route same-origin. The web app is
+// served from it, so opening it up would only widen the cross-site surface —
+// which the tRPC mutation origin guard (see packages/api/src/trpc.ts) exists to
+// shrink.
+const handler = async (req: NextRequest) =>
+  fetchRequestHandler({
     endpoint: "/api/trpc",
     router: appRouter,
     req,
@@ -35,10 +16,5 @@ const handler = async (req: NextRequest) => {
       console.error(`>>> tRPC Error on '${path}'`, error);
     },
   });
-
-  setCorsHeaders(response);
-
-  return response;
-};
 
 export { handler as GET, handler as POST };

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+// Catches errors thrown by a root layout itself, so it replaces the layout
+// entirely and must render its own <html>/<body>. Kept dependency-free — the
+// providers and fonts the app usually supplies may be exactly what failed.
+const GlobalError = ({ error, reset }: GlobalErrorProps) => {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body className="bg-background text-foreground font-sans antialiased">
+        <main className="flex min-h-dvh flex-col items-center justify-center gap-6 p-8 text-center">
+          <div className="space-y-2">
+            <h1 className="text-2xl font-semibold">Something went wrong</h1>
+            <p className="text-muted-foreground">The application failed to load.</p>
+          </div>
+          <button
+            type="button"
+            onClick={reset}
+            className="bg-primary text-primary-foreground hover:bg-primary/80 inline-flex h-9 items-center rounded-md px-4 text-sm font-medium transition-colors"
+          >
+            Try again
+          </button>
+        </main>
+      </body>
+    </html>
+  );
+};
+
+export default GlobalError;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { buttonVariants } from "@repo/ui/components/button";
+
+import "./styles/globals.css";
+
+// The app has multiple root layouts (one per route group under (frame)/(main)),
+// so the global not-found has no root layout to render into and must supply its
+// own <html>/<body> and stylesheet.
+const NotFound = () => (
+  <html lang="en" suppressHydrationWarning>
+    <body className="bg-background text-foreground font-sans antialiased">
+      <main className="flex min-h-dvh flex-col items-center justify-center gap-6 p-8 text-center">
+        <div className="space-y-2">
+          <p className="text-muted-foreground text-sm font-medium">404</p>
+          <h1 className="text-2xl font-semibold">Page not found</h1>
+          <p className="text-muted-foreground">
+            The page you&apos;re looking for doesn&apos;t exist or has moved.
+          </p>
+        </div>
+        <Link href="/" className={buttonVariants()}>
+          Back home
+        </Link>
+      </main>
+    </body>
+  </html>
+);
+
+export default NotFound;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { buttonVariants } from "@repo/ui/components/button";
+import { Button } from "@repo/ui/components/button";
 
 import "./styles/globals.css";
 
@@ -17,9 +17,7 @@ const NotFound = () => (
             The page you&apos;re looking for doesn&apos;t exist or has moved.
           </p>
         </div>
-        <Link href="/" className={buttonVariants()}>
-          Back home
-        </Link>
+        <Button render={<Link href="/" />}>Back home</Button>
       </main>
     </body>
   </html>

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,8 +15,6 @@
     "@repo/db": "workspace:^",
     "@trpc/server": "catalog:",
     "better-auth": "catalog:",
-    "next": "catalog:",
-    "react": "catalog:",
     "superjson": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/api/src/auth/auth.ts
+++ b/packages/api/src/auth/auth.ts
@@ -1,15 +1,18 @@
-import { cache } from "react";
-import { headers } from "next/headers";
 import { db } from "@repo/db/drizzle-client";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
-const baseUrl =
+export const baseUrl =
   process.env.VERCEL_ENV === "production"
     ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
     : process.env.VERCEL_ENV === "preview"
       ? `https://${process.env.VERCEL_URL}`
       : "http://localhost:3000";
+
+// Origins allowed to drive authenticated requests. Only the web app runs
+// same-origin as baseUrl. Consumed by better-auth's own Origin checks and by
+// the tRPC mutation guard (see packages/api/src/trpc.ts).
+export const trustedOrigins = [baseUrl];
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -19,14 +22,18 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
   },
+  trustedOrigins,
+  // Persist rate-limit counters in the database. The default in-memory store
+  // keeps per-instance counters, so on serverless (Vercel) the effective limit
+  // multiplies across cold-started instances and resets on every deploy. 10
+  // requests/60s per IP throttles credential-stuffing against the auth routes.
+  rateLimit: {
+    enabled: true,
+    storage: "database",
+    window: 60,
+    max: 10,
+  },
 });
 
 export type Auth = typeof auth;
 export type Session = Auth["$Infer"]["Session"];
-
-/**
- * Cached function to get the current user session
- * Uses React cache to avoid unnecessary re-fetching
- * @returns Promise<Session | null> - The current user session or null if not authenticated
- */
-export const getSession = cache(async () => auth.api.getSession({ headers: await headers() }));

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -11,17 +11,12 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
-import { auth } from "./auth/auth";
+import { auth, trustedOrigins } from "./auth/auth";
 
 /**
- * 1. CONTEXT
- *
- * This section defines the "contexts" that are available in the backend API.
- *
- * These allow you to access things when processing a request, like the database, the session, etc.
- *
- * This helper generates the "internals" for a tRPC context. The API handler and RSC clients each
- * wrap this and provides the required context.
+ * Builds the per-request context. Callers supply headers rather than reading
+ * them here, so the same code serves the fetch handler and the in-process RSC
+ * caller, which have no shared request object.
  *
  * @see https://trpc.io/docs/server/context
  */
@@ -33,16 +28,18 @@ export const createTRPCContext = async (opts: { headers: Headers }) => {
   return {
     session,
     db,
+    // Browser-supplied request provenance. Captured here because a tRPC
+    // middleware cannot read raw request headers; read by the mutation origin
+    // guard below. Both null for non-browser callers (server-to-server).
+    origin: opts.headers.get("origin"),
+    secFetchSite: opts.headers.get("sec-fetch-site"),
   };
 };
 
 export type TRPCContext = Awaited<ReturnType<typeof createTRPCContext>>;
 
 /**
- * 2. INITIALIZATION
- *
- * This is where the trpc api is initialized, connecting the context and
- * transformer
+ * Initialize the tRPC API, connecting the context and transformer.
  */
 const t = initTRPC.context<TRPCContext>().create({
   transformer: superjson,
@@ -55,43 +52,58 @@ const t = initTRPC.context<TRPCContext>().create({
   }),
 });
 
-/**
- * Create a server-side caller
- * @see https://trpc.io/docs/server/server-side-calls
- */
+/** @see https://trpc.io/docs/server/server-side-calls */
 export const createCallerFactory = t.createCallerFactory;
 
-/**
- * 3. ROUTER & PROCEDURE (THE IMPORTANT BIT)
- *
- * These are the pieces you use to build your tRPC API. You should import these
- * a lot in the /src/server/api/routers folder
- */
-
-/**
- * This is how you create new routers and subrouters in your tRPC API
- * @see https://trpc.io/docs/router
- */
+/** @see https://trpc.io/docs/router */
 export const createTRPCRouter = t.router;
 
-/**
- * Public (unauthed) procedure
- *
- * This is the base piece you use to build new queries and mutations on your
- * tRPC API. It does not guarantee that a user querying is authorized, but you
- * can still access user session data if they are logged in
- */
-export const publicProcedure = t.procedure;
+const TRUSTED_ORIGINS = new Set(trustedOrigins);
 
 /**
- * Protected (authenticated) procedure
- *
- * If you want a query or mutation to ONLY be accessible to logged in users, use this. It verifies
- * the session is valid and guarantees `ctx.session.user` is not null.
+ * True when a request carries browser provenance that isn't same-origin or an
+ * allow-listed origin. Defence-in-depth CSRF check: better-auth's own Origin
+ * checks only cover /api/auth/*, so this guards /api/trpc. Non-browser callers
+ * send neither header and are left alone; session auth still applies.
+ */
+const isUntrustedOrigin = (origin: string | null, secFetchSite: string | null) => {
+  // Sec-Fetch-Site is set by the browser and cannot be forged from script.
+  if (secFetchSite === "same-origin" || secFetchSite === "none") return false;
+  // No browser provenance at all — not a browser CSRF vector.
+  if (!origin && !secFetchSite) return false;
+  // A cross-site/same-site label, or any Origin, must match the allow-list.
+  // Fail closed: a stripped Origin under a cross-site label is rejected.
+  return origin === null || !TRUSTED_ORIGINS.has(origin);
+};
+
+/**
+ * Rejects state-changing calls whose origin isn't trusted — defence-in-depth
+ * against CSRF, layered under session auth rather than replacing it. Queries are
+ * side-effect-free and pass through untouched.
+ */
+const enforceTrustedOriginOnMutation = t.middleware(({ ctx, type, next }) => {
+  if (type === "mutation" && isUntrustedOrigin(ctx.origin, ctx.secFetchSite)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "Cross-origin request rejected",
+    });
+  }
+  return next();
+});
+
+/**
+ * Unauthenticated procedure. Does not require a session, but `ctx.session` is
+ * still populated when the caller happens to be logged in.
+ */
+export const publicProcedure = t.procedure.use(enforceTrustedOriginOnMutation);
+
+/**
+ * Requires a session, and narrows `ctx.session.user` to non-nullable for the
+ * handler.
  *
  * @see https://trpc.io/docs/procedures
  */
-export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
+export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
   if (!ctx.session?.user) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }

--- a/packages/db/src/drizzle-schema-auth.ts
+++ b/packages/db/src/drizzle-schema-auth.ts
@@ -85,6 +85,17 @@ export const verification = sqliteTable(
   (table) => [index("verification_identifier_idx").on(table.identifier)],
 );
 
+// better-auth's database rate-limit store (rateLimit.storage = "database" in
+// auth.ts). Keyed by IP+path; `key` is unique so the counter upsert is a single
+// indexed lookup. Hand-added — the CLI regen (generate:auth-schema) emits this
+// table too, so re-check it after regenerating.
+export const rateLimit = sqliteTable("rate_limit", {
+  id: text("id").primaryKey(),
+  key: text("key").notNull().unique(),
+  count: integer("count").notNull(),
+  lastRequest: integer("last_request").notNull(),
+});
+
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,7 +12,6 @@
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
-    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -177,9 +177,12 @@ export type AlertState = {
 
 type Listener = () => void;
 
+const initialAlertState: AlertState = { open: false, title: "" };
+const initialListeners: Listener[] = [];
+
 const alertDialogStore = {
-  state: { open: false, title: "" } as AlertState,
-  listeners: [] as Listener[],
+  state: initialAlertState,
+  listeners: initialListeners,
   subscribe: (listener: Listener) => {
     alertDialogStore.listeners.push(listener);
     return () => {

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -53,7 +53,7 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
+        if (e.target instanceof HTMLElement && e.target.closest("button")) {
           return;
         }
         e.currentTarget.parentElement

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -3,7 +3,9 @@
 @import "shadcn/tailwind.css";
 
 @custom-variant dark (&:is(.dark *));
-@source "../../../../apps/**/*.{ts,tsx}";
+/* No apps/** scan here: each app's sources are auto-detected from its own build
+   root, so scanning apps/** from this shared stylesheet would make every app
+   ship every other app's classes. */
 @source "../../../../content/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -889,12 +889,6 @@ importers:
       better-auth:
         specifier: 'catalog:'
         version: 1.6.23(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@prisma/client@7.4.2(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(typescript@6.0.3))(kysely@0.29.3)(mysql2@3.15.3)(postgres@3.4.7)(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)))(mongodb@7.1.0)(mysql2@3.15.3)(next@16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(prisma@7.4.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      next:
-        specifier: 'catalog:'
-        version: 16.2.10(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react:
-        specifier: 'catalog:'
-        version: 19.2.7
       superjson:
         specifier: 'catalog:'
         version: 2.2.6


### PR DESCRIPTION
Backports recent `init` template fixes into uicapsule, adapting Postgres→SQLite where needed. Component-showcase fork, so extension/expo/organization concerns from init don't apply — comments trimmed accordingly.

## Fixes (init sha)

- [x] **auth rate-limiting** (SECURITY, `448b92aeae97`) — `rateLimit: { enabled, storage: "database", window: 60, max: 10 }` on `betterAuth()`; new `rate_limit` sqlite table (`id/key/count/last_request` + unique `key`).
- [x] **tRPC CSRF + close CORS** (SECURITY, `ba74ba94aa7c` + `61e40bcbb2ba`) — `trustedOrigins` export + `enforceTrustedOriginOnMutation` middleware on public/protected procedures; removed wildcard `Access-Control-Allow-Origin: *` (+ `OPTIONS`/`setCorsHeaders`) from the tRPC route — every client is same-origin.
- [x] **error surface** (`f1f9b801e721`) — added `global-error.tsx` + `not-found.tsx`. Fork uses **multiple root layouts** (one per route group, no `app/layout.tsx`), so `not-found` supplies its own `<html>/<body>` + stylesheet per Next's multi-root requirement.
- [x] **trim tRPC preamble** (`f4dc365ba1a9`) — replaced create-t3-app tutorial comments with init's terse comments.
- [x] **ui source glob** (`54a7422bfad4`) — dropped the `apps/**` `@source`. Fork also has a `content/**` glob (repo-root, not an app build root) — left intact.
- [x] **decouple @repo/api from Next** (`ebf4c6558969`) — dropped the dead `getSession` export (react cache + next/headers, zero callers) and removed `next`+`react` from `packages/api/package.json`.
- [x] **remove orphan vitest script** (`6b9805ffb8ba`) — deleted `"test": "vitest run"` (no config/dep/tests).
- [x] **type-safety spot-check** (`dc10d19663ac`) — `input-group` `(e.target as HTMLElement)` → `instanceof`; `alert-dialog` store `as AlertState`/`as Listener[]` → hoisted typed consts.

## Notes / double-check

- **Migration**: fork is push-based (empty, untracked `drizzle/`, no `generate` script). Validated the schema generates correct SQL, but committed **no migration file** — apply via `pnpm db:push` / `db:push-remote`.
- **CSRF value**: fork cookies default to `SameSite=Lax` (no extension iframe), so the browser already backstops cross-site POSTs; this middleware is defence-in-depth over `/api/trpc`. Comments adapted to drop init's `SameSite=None`/extension rationale.
- `next.config.js` left as-is (fork has real fs logic).
- `plans/component-roadmap.md` left as-is (intentional).

## Verify

- `pnpm install` clean (pre-existing peer warnings in `content/*` only).
- Typecheck: `@repo/db`, `@repo/api`, `@repo/ui`, `web` all pass.
- `oxlint` + `oxfmt --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports init template security hardening and cleanup: DB-backed auth rate limiting (10 req/60s/IP), trusted-origin guard on tRPC mutations with same-origin `/api/trpc` (no wildcard CORS), multi-root-safe `global-error.tsx`/`not-found.tsx`, and decouples `@repo/api` from Next/React with small UI/type cleanups. Also fixes the 404 CTA by rendering the `@repo/ui` `Button` instead of the client-only `buttonVariants`.

- **Migration**
  - Apply DB changes: run `pnpm db:push` (adds `rate_limit` table).

<sup>Written for commit 3c370603e1a913e3ce18b175d624c3e6763d4c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

