### PR TITLE
Delete empty content stubs, guard against future ones

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ pnpm format:fix       # Fix formatting
 pnpm db:push          # Push local db schema
 pnpm db:push-remote   # Push to production Turso
 pnpm new:content <slug>  # Scaffold a new content component in content/
+pnpm check:content    # Fail if any content/<slug> is not a loadable component
 ```
 
 ## Verification Contract
@@ -60,6 +61,12 @@ pnpm new:content <slug>  # Scaffold a new content component in content/
 Every change must leave all four green: `pnpm typecheck`, `pnpm lint` (oxlint),
 `pnpm format` (oxfmt), `pnpm build`. There are **zero tests in the repo today** — don't
 assume a suite has your back.
+
+`pnpm build` runs `check:content` first (turbo task `//#check:content`): the gallery loader
+in `content-fs.ts` silently drops a `content/<slug>` that lacks its `meta.json` + `preview.tsx`
+pair (or, for a remote component, `iframeUrl`/`sourceUrl`), so a half-scaffolded stub used to
+vanish with no error and pile up. The guard turns that silence into a failed build — do not
+remove it. Finish the component or delete the directory; scaffold with `pnpm new:content`.
 
 ## Decisions (do not re-litigate)
 

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "//#check:content"],
       "outputs": [".next/**", "!.next/cache/**", "next-env.d.ts"]
     },
     "dev": {

--- a/content/timeline/meta.json
+++ b/content/timeline/meta.json
@@ -1,3 +1,0 @@
-{
-  "name": "Timeline"
-}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "oxfmt",
     "lint:fix": "oxlint --fix",
     "format:fix": "oxfmt --write",
-    "new:content": "tsx scripts/new-content.ts"
+    "new:content": "tsx scripts/new-content.ts",
+    "check:content": "tsx scripts/check-content.ts"
   },
   "devDependencies": {
     "citty": "^0.2.2",

--- a/scripts/check-content.ts
+++ b/scripts/check-content.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env tsx
+/**
+ * Fails the build if any `content/<slug>/` directory is not a loadable
+ * component. This mirrors the acceptance rule in
+ * `apps/web/src/lib/content/content-fs.ts` (`buildComponent`), which otherwise
+ * SILENTLY drops an invalid directory by returning null — so a half-scaffolded
+ * or abandoned stub disappears from the gallery with no error, and accumulates
+ * unnoticed. This guard turns that silence into a failed build.
+ *
+ * A directory is valid when it has a `meta.json` AND either:
+ *   - `meta.type === "remote"` with both `iframeUrl` and `sourceUrl`, or
+ *   - (the default, local) a root `preview.tsx`.
+ */
+import { readFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import consola from "consola";
+
+const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+const contentRoot = join(repoRoot, "content");
+
+type RawMeta = {
+  type?: "local" | "remote";
+  iframeUrl?: string;
+  sourceUrl?: string;
+};
+
+const readJson = async (path: string): Promise<RawMeta | null> => {
+  try {
+    return JSON.parse(await readFile(path, "utf-8")) as RawMeta;
+  } catch {
+    return null;
+  }
+};
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await readFile(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Returns the reason a directory is invalid, or null when it is valid. */
+const validate = async (slug: string): Promise<string | null> => {
+  const dir = join(contentRoot, slug);
+  const meta = await readJson(join(dir, "meta.json"));
+  if (!meta) return "missing or unparseable meta.json";
+
+  if (meta.type === "remote") {
+    if (!meta.iframeUrl || !meta.sourceUrl) {
+      return 'type "remote" requires both iframeUrl and sourceUrl in meta.json';
+    }
+    return null;
+  }
+
+  if (!(await fileExists(join(dir, "preview.tsx")))) {
+    return "missing preview.tsx (a local component must export a default preview)";
+  }
+  return null;
+};
+
+const main = async (): Promise<void> => {
+  const entries = await readdir(contentRoot, { withFileTypes: true }).catch(() => []);
+  const slugs = entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => entry.name)
+    .sort();
+
+  const failures: { slug: string; reason: string }[] = [];
+  for (const slug of slugs) {
+    const reason = await validate(slug);
+    if (reason) failures.push({ slug, reason });
+  }
+
+  if (failures.length > 0) {
+    consola.error(
+      `Found ${failures.length} invalid content director${failures.length === 1 ? "y" : "ies"}:`,
+    );
+    for (const { slug, reason } of failures) {
+      consola.error(`  content/${slug} — ${reason}`);
+    }
+    consola.info(
+      "The gallery loader drops these silently. Finish the component (meta.json + preview.tsx), " +
+        "or delete the directory. To scaffold one: pnpm new:content <slug>.",
+    );
+    process.exit(1);
+  }
+
+  consola.success(`Checked ${slugs.length} content components — all valid.`);
+};
+
+main().catch((error) => {
+  consola.error(error);
+  process.exit(1);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,9 @@
     "build": {
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "//#check:content": {
+      "inputs": ["content/**", "scripts/check-content.ts"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Follow-up to #86.

## What

- Delete `content/timeline/` (a lone 25-byte `meta.json`, no source) and `content/voxel-landing/` (untracked cruft — not even a `meta.json`). Both rendered the app's 404 page. During the #86 simplify pass, two review agents each burned time deciding whether these were broken or unbuilt.
- Add `scripts/check-content.ts`, wired into the build as turbo task `//#check:content` that `@repo/web:build` depends on.

## Why a guard

`content-fs.ts` (`buildComponent`) **silently drops** a `content/<slug>` that isn't loadable — it returns `null` and the slug just disappears from the gallery, registry and search. So a half-scaffolded or abandoned directory vanishes with no error and piles up unnoticed. That's exactly how these two accumulated.

The guard mirrors the loader's own acceptance rule — a directory is valid only with `meta.json` **and** either `preview.tsx` (local) or `iframeUrl`+`sourceUrl` (remote) — and turns the silent drop into a failed build with an actionable message.

## Scope

- `content/timeline/`, `content/voxel-landing/` — deleted
- `scripts/check-content.ts` — new validator (mirrors `apps/web/src/lib/content/content-fs.ts`)
- `package.json` — `check:content` script
- `turbo.json` / `apps/web/turbo.json` — `//#check:content` task, made a `@repo/web:build` dependency
- `CLAUDE.md` — documents the guard under Common Commands + Verification Contract

## Verification

- Clean tree passes: `Checked 36 content components — all valid`
- An injected stub (`meta.json` only) exits 1 with the reason
- A remote component with no `preview.tsx` (`line-chart`) still passes
- `turbo run build` runs `//#check:content` before the web build; typecheck / lint / format / build all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGVEtevCNiafNZz14nrCXZ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove two empty content stubs and add a build-time guard that fails if any `content/<slug>` is not loadable. This prevents silent drops from the gallery and stops broken or half-built content from slipping in.

- New Features
  - Added `scripts/check-content.ts` to verify each `content/<slug>` has `meta.json` plus `preview.tsx` (local) or `iframeUrl` + `sourceUrl` (remote).
  - Wired into Turbo as `//#check:content`; `@repo/web:build` depends on it. Exposed as `pnpm check:content`.

- Bug Fixes
  - Deleted `content/timeline/` and `content/voxel-landing/` stubs that rendered 404s.

<sup>Written for commit a013e52046032998dbd8a3a4558007b251e0f074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

