### PR TITLE
Move Silly to the front of the category filter list

### DIFF
--- a/apps/web/src/lib/content/content-categories.ts
+++ b/apps/web/src/lib/content/content-categories.ts
@@ -5,6 +5,7 @@ export type ContentFilter = {
 };
 
 export const contentCategories: ContentFilter[] = [
+  { name: "Silly", slug: "silly" },
   { name: "AI", slug: "ai" },
   { name: "Productivity", slug: "productivity" },
   { name: "Social", slug: "social" },
@@ -16,7 +17,6 @@ export const contentCategories: ContentFilter[] = [
   { name: "Business", slug: "business" },
   { name: "Games", slug: "games" },
   { name: "Utilities", slug: "utilities" },
-  { name: "Silly", slug: "silly" },
 ];
 
 /**


### PR DESCRIPTION
Reorders `contentCategories` in `apps/web/src/lib/content/content-categories.ts` so `Silly` is the first entry instead of the last.

The three filter lists in that file are hand-authored with no sorting applied anywhere, so array order is the display order — this moves Silly to the top of the category filter dropdown and of the category section in search.

New category order:

`Silly` · AI · Productivity · Social · Entertainment · Education · Finance · Health & Fitness · Design · Business · Games · Utilities

Note: `silly` is still in `unlistedTags`, so silly components remain hidden from the grid, feed, and trending until the tag is explicitly filtered for. This change only affects where the filter entry appears in the list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbCNzz2aPqv5LNMads3UX6)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered `contentCategories` so `Silly` appears first in the category filter and in search, making it easier to find. This only changes display order; `silly` stays in `unlistedTags`, so content remains hidden unless the tag is explicitly filtered.

<sup>Written for commit cd70e0ff6c3565ad435b4881ad2a82600ecd2fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

