### PR TITLE
feat(effort-picker): make the curls landing a celebration

### DIFF
--- a/content/effort-picker/curl-fanfare.tsx
+++ b/content/effort-picker/curl-fanfare.tsx
@@ -14,18 +14,24 @@ import { EFFORT_THEMES, notchX } from "./effort-theme";
  * so the celebration is *about the number you earned*, not a generic confetti
  * cannon bolted to the card. Land on Light and the fireworks go off over on the
  * left, next to nothing; land on Ultra and they go off at the end of the track.
- * Same show, different address, and the address is the joke.
+ *
+ * And it is not the same show at both ends. The whole thing is scaled by
+ * `power` — how far up the track you actually got — so Light gets a shrug and
+ * Ultra gets the works. Handing out identical fireworks for four curls and for
+ * sixteen would undo the only thing the card is measuring.
  *
  * Layers, in the order the eye reads them: the fill ignites and a bloom opens at
  * the notch, an anamorphic flare rips along the track, streaks fan out, rings
  * chase them, and the whole thing rains sparks over the card while the rim
- * lights up.
+ * lights up. The last three of those don't show up at all until you've earned
+ * them.
  */
 
 /** How long the layer stays mounted, in ms. The card tears it down after this —
- * every animation below has finished and faded by then. */
+ * every animation below has finished and faded by then, at any power. */
 export const FANFARE_MS = 1700;
 
+/** Ray and spark counts at full power. Both scale down to a handful at Light. */
 const STREAK_COUNT = 15;
 const SPARK_COUNT = 30;
 /** Streaks start this far out from the notch instead of at it. Fifteen bars
@@ -46,9 +52,26 @@ const FAN_TO = 25;
  * it's born. */
 const FAN_LEAN = 30;
 
+/** Power below which a layer sits the celebration out entirely. The glare rake
+ * and the third shockwave are the two loudest things here; a four-curl take has
+ * not bought either. */
+const GLARE_FLOOR = 0.45;
+
 /** violet-400, as raw channels — half of these colours are built inside template
  * strings for `boxShadow` and gradients, where a Tailwind class can't reach. */
 const VIOLET = "167,139,250";
+
+const lerp = (from: number, to: number, t: number) => from + (to - from) * t;
+
+/**
+ * How much celebration the take earned, 0 (bottom notch) to 1 (top). Exported
+ * because the card scales its own share of the landing — the flashbulb, the
+ * knob's slam, the kick, the verdict's halo — off the same number, and a
+ * celebration that disagreed with itself about how big it was would read as a
+ * bug rather than a scale.
+ */
+export const fanfarePower = (theme: EffortTheme, level: number) =>
+  notchX(theme, level) / TRACK_TRAVEL;
 
 /**
  * Deterministic 0..1 from an index. The spray has to look scattered without
@@ -61,7 +84,7 @@ const scatter = (index: number, salt: number) => {
 };
 
 type CurlFanfareProps = {
-  /** The level the take rounded down to — the show's origin point. */
+  /** The level the take rounded down to — the show's origin point, and its size. */
   level: number;
   theme: EffortTheme;
 };
@@ -69,17 +92,20 @@ type CurlFanfareProps = {
 export const CurlFanfare = ({ level, theme }: CurlFanfareProps) => {
   const tokens = EFFORT_THEMES[theme];
   const landedX = notchX(theme, level);
+  const power = fanfarePower(theme, level);
   // Card coordinates, not track coordinates: the fanfare covers the whole card,
   // so the notch has to be re-expressed against the card's own padding box. The
   // track sits flush in that box, which makes this the knob's centre.
   const anchorLeft = CARD_PADDING + KNOB_SIZE / 2 + landedX;
   const anchorBottom = CARD_PADDING + KNOB_SIZE / 2;
-  const lean = (0.5 - landedX / TRACK_TRAVEL) * 2 * FAN_LEAN;
+  const lean = (0.5 - power) * 2 * FAN_LEAN;
 
   return (
     <>
       {/* The card's own edge, lit. Unclipped, so the outer bloom escapes the
-          popover the way a real light source would. */}
+          popover the way a real light source would — faintly at Light, where it
+          reads as the card catching a little of the glow rather than announcing
+          anything. */}
       <motion.span
         aria-hidden
         className="pointer-events-none absolute inset-0 rounded-[inherit]"
@@ -87,7 +113,7 @@ export const CurlFanfare = ({ level, theme }: CurlFanfareProps) => {
           boxShadow: `inset 0 0 0 2px rgba(196,181,253,0.7), inset 0 0 40px rgba(${VIOLET},0.28), 0 0 60px rgba(139,92,246,0.45)`,
         }}
         initial={{ opacity: 0 }}
-        animate={{ opacity: [0, 1, 0] }}
+        animate={{ opacity: [0, lerp(0.22, 1, power), 0] }}
         transition={{ duration: 1.3, times: [0, 0.1, 1], ease: "easeOut" }}
       />
 
@@ -106,7 +132,9 @@ export const CurlFanfare = ({ level, theme }: CurlFanfareProps) => {
         className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit] isolate"
       >
         {/* The fill charges: a hot band runs the length of everything the take
-            earned, arriving at the notch just as the knob commits to it. */}
+            earned, arriving at the notch just as the knob commits to it. This one
+            layer needs no scaling — it *is* the scale, since there's barely any
+            fill to run down at the bottom of the track. */}
         <span
           className="absolute overflow-hidden"
           style={{
@@ -129,60 +157,67 @@ export const CurlFanfare = ({ level, theme }: CurlFanfareProps) => {
           />
         </span>
 
-        <Glare />
+        {power >= GLARE_FLOOR && <Glare power={power} />}
 
         {/* Zero-sized anchor at the notch. Everything below centres on it the
             same way the per-rep `Sparks` do — position once, then only ever
             animate transforms. */}
         <span className="absolute size-0" style={{ left: anchorLeft, bottom: anchorBottom }}>
-          <Bloom />
-          <Flare />
-          <Streaks lean={lean} />
-          <Rings />
-          <SparkSpray lean={lean} />
+          <Bloom power={power} />
+          <Flare power={power} />
+          <Streaks power={power} lean={lean} />
+          <Rings power={power} />
+          <SparkSpray power={power} lean={lean} />
         </span>
       </span>
     </>
   );
 };
 
+type PoweredProps = { power: number };
+
 /**
- * The soft glow under everything else. Deliberately smaller than the card: an
- * earlier pass sized it to swallow the whole popover and the result was a white
- * rectangle with a knob in it. The celebration has to stay *local to the notch*,
- * or the card stops being a card for half a second.
+ * The soft glow under everything else. Deliberately smaller than the card even
+ * at full power: an earlier pass sized it to swallow the whole popover and the
+ * result was a white rectangle with a knob in it. The celebration has to stay
+ * *local to the notch*, or the card stops being a card for half a second.
  */
-const Bloom = () => (
+const Bloom = ({ power }: PoweredProps) => (
   <motion.span
     className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full"
     style={{
-      width: 440,
-      height: 440,
+      width: lerp(170, 440, power),
+      height: lerp(170, 440, power),
       backgroundImage: `radial-gradient(circle, rgba(${VIOLET},0.55) 0%, rgba(139,92,246,0.3) 30%, rgba(109,40,217,0.14) 52%, transparent 72%)`,
     }}
     initial={{ scale: 0.12, opacity: 0 }}
-    animate={{ scale: [0.12, 1, 1.25], opacity: [0, 1, 0] }}
-    transition={{ duration: 1.15, times: [0, 0.16, 1], ease: "easeOut" }}
+    animate={{ scale: [0.12, 1, 1.25], opacity: [0, lerp(0.55, 1, power), 0] }}
+    transition={{ duration: lerp(0.7, 1.15, power), times: [0, 0.16, 1], ease: "easeOut" }}
   />
 );
 
 /** The anamorphic streak along the track axis. One horizontal bar does more for
- * "this is a light source" than any amount of radial spray. */
-const Flare = () => (
+ * "this is a light source" than any amount of radial spray — which is why it's
+ * the one ray that survives all the way down to Light, just short and dim. */
+const Flare = ({ power }: PoweredProps) => (
   <motion.span
     className="absolute mix-blend-screen"
     style={{
-      width: 480,
+      width: lerp(160, 480, power),
       height: 4,
-      x: -240,
+      x: lerp(-80, -240, power),
       y: -2,
       borderRadius: 4,
       backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(${VIOLET},0.7) 30%, rgba(255,255,255,0.95) 50%, rgba(${VIOLET},0.7) 70%, rgba(255,255,255,0) 100%)`,
       filter: "blur(1.5px)",
     }}
     initial={{ scaleX: 0.05, scaleY: 0.4, opacity: 0 }}
-    animate={{ scaleX: [0.05, 1, 1.1], scaleY: [0.4, 1, 0.3], opacity: [0, 0.9, 0] }}
-    transition={{ duration: 0.95, times: [0, 0.14, 1], ease: "easeOut" }}
+    animate={{
+      scaleX: [0.05, 1, 1.1],
+      scaleY: [0.4, 1, 0.3],
+      opacity: [0, lerp(0.5, 0.9, power), 0],
+    }}
+    transition={{ duration: lerp(0.6, 0.95, power), times: [0, 0.14, 1], ease: "easeOut" }}
   />
 );
 
@@ -190,9 +225,10 @@ const Flare = () => (
  * A single bar of glare raked across the whole card, once. The notch burst is
  * pinned to one corner by definition; this is the only layer that touches every
  * part of the card, and it's what makes the celebration feel card-sized rather
- * than corner-sized.
+ * than corner-sized. Which is exactly why a low take doesn't get one — it is the
+ * difference between "you finished" and "look at this card".
  */
-const Glare = () => (
+const Glare = ({ power }: PoweredProps) => (
   <motion.span
     className="absolute -top-1/4 h-[150%] w-28 mix-blend-screen"
     style={{
@@ -201,7 +237,7 @@ const Glare = () => (
       backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(221,214,254,0.22) 45%, rgba(255,255,255,0.34) 55%, rgba(255,255,255,0) 100%)`,
     }}
     initial={{ x: 0, opacity: 0 }}
-    animate={{ x: [0, 660], opacity: [0, 1, 1, 0] }}
+    animate={{ x: [0, 660], opacity: [0, power, power, 0] }}
     transition={{ duration: 0.7, times: [0, 0.15, 0.7, 1], ease: "easeOut" }}
   />
 );
@@ -217,58 +253,72 @@ const Glare = () => (
  * first composited frame of the burst can come out as one white flash. The soft
  * edge is baked into the gradient instead, which costs nothing.
  */
-const Streaks = ({ lean }: { lean: number }) => (
-  <>
-    {Array.from({ length: STREAK_COUNT }, (_, index) => {
-      const angle =
-        lean + FAN_FROM + ((index + scatter(index, 1) * 0.7) / STREAK_COUNT) * (FAN_TO - FAN_FROM);
-      const length = 110 + scatter(index, 2) * 230;
-      const thickness = 2 + scatter(index, 3) * 3.5;
+const Streaks = ({ power, lean }: PoweredProps & { lean: number }) => {
+  // Rays thin out *and* shorten as the take gets weaker — dropping only the
+  // count leaves three full-length spears, which reads as a broken burst rather
+  // than a small one.
+  const count = Math.round(lerp(3, STREAK_COUNT, power));
 
-      return (
-        <span
-          key={index}
-          className="absolute size-0"
-          style={{ rotate: `${angle}deg`, transformOrigin: "0% 0%" }}
-        >
-          <motion.span
-            className="absolute mix-blend-screen"
-            style={{
-              left: STREAK_GAP,
-              top: -thickness / 2,
-              width: length,
-              height: thickness,
-              borderRadius: thickness,
-              transformOrigin: "0% 50%",
-              backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0.95) 0%, rgba(${VIOLET},0.85) 30%, rgba(139,92,246,0.35) 65%, rgba(139,92,246,0) 100%)`,
-            }}
-            initial={{ scaleX: 0, opacity: 0 }}
-            animate={{ scaleX: [0, 1, 1], opacity: [0, 1, 0] }}
-            transition={{
-              duration: 0.75 + scatter(index, 4) * 0.5,
-              times: [0, 0.24, 1],
-              ease: "easeOut",
-              delay: scatter(index, 5) * 0.12,
-            }}
-          />
-        </span>
-      );
-    })}
-  </>
-);
+  return (
+    <>
+      {Array.from({ length: count }, (_, index) => {
+        const angle =
+          lean + FAN_FROM + ((index + scatter(index, 1) * 0.7) / count) * (FAN_TO - FAN_FROM);
+        const length = lerp(55, 110, power) + scatter(index, 2) * lerp(70, 230, power);
+        const thickness = 2 + scatter(index, 3) * 3.5;
 
-/** Three shockwaves, staggered. Width and height are animated rather than
- * `scale` so the stroke stays hairline-thin as the ring grows — a scaled border
- * fattens up and stops reading as a shockwave. */
-const Rings = () => (
+        return (
+          <span
+            key={index}
+            className="absolute size-0"
+            style={{ rotate: `${angle}deg`, transformOrigin: "0% 0%" }}
+          >
+            <motion.span
+              className="absolute mix-blend-screen"
+              style={{
+                left: STREAK_GAP,
+                top: -thickness / 2,
+                width: length,
+                height: thickness,
+                borderRadius: thickness,
+                transformOrigin: "0% 50%",
+                backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0.95) 0%, rgba(${VIOLET},0.85) 30%, rgba(139,92,246,0.35) 65%, rgba(139,92,246,0) 100%)`,
+              }}
+              initial={{ scaleX: 0, opacity: 0 }}
+              animate={{ scaleX: [0, 1, 1], opacity: [0, lerp(0.7, 1, power), 0] }}
+              transition={{
+                duration: 0.75 + scatter(index, 4) * 0.5,
+                times: [0, 0.24, 1],
+                ease: "easeOut",
+                delay: scatter(index, 5) * 0.12,
+              }}
+            />
+          </span>
+        );
+      })}
+    </>
+  );
+};
+
+/**
+ * Shockwaves, staggered — one at the bottom of the track, three at the top.
+ * Width and height are animated rather than `scale` so the stroke stays
+ * hairline-thin as the ring grows; a scaled border fattens up and stops reading
+ * as a shockwave.
+ */
+const Rings = ({ power }: PoweredProps) => (
   <>
-    {[0, 0.1, 0.22].map((delay, index) => (
+    {[0, 0.1, 0.22].slice(0, 1 + Math.round(power * 2)).map((delay, index) => (
       <motion.span
         key={delay}
         className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-violet-200/70 mix-blend-screen"
         style={{ boxShadow: `0 0 22px rgba(${VIOLET},0.55)` }}
         initial={{ width: 20, height: 20, opacity: 0 }}
-        animate={{ width: 280 + index * 110, height: 280 + index * 110, opacity: [0, 0.8, 0] }}
+        animate={{
+          width: lerp(130, 280, power) + index * 110,
+          height: lerp(130, 280, power) + index * 110,
+          opacity: [0, lerp(0.5, 0.8, power), 0],
+        }}
         transition={{ duration: 0.95, delay, times: [0, 0.1, 1], ease: [0.16, 1, 0.3, 1] }}
       />
     ))}
@@ -279,46 +329,51 @@ const Rings = () => (
  * two-segment easing is what sells it — `easeOut` on the way up, `easeIn` on the
  * way down, because a firework that decelerates into the floor looks like it's
  * being lowered on a wire. */
-const SparkSpray = ({ lean }: { lean: number }) => (
-  <>
-    {Array.from({ length: SPARK_COUNT }, (_, index) => {
-      const heading = ((lean + FAN_FROM + scatter(index, 6) * (FAN_TO - FAN_FROM)) * Math.PI) / 180;
-      const speed = 90 + scatter(index, 7) * 320;
-      const dx = Math.cos(heading) * speed;
-      const dy = Math.sin(heading) * speed;
-      const size = 3 + scatter(index, 8) * 4;
-      const elongated = index % 3 === 0;
+const SparkSpray = ({ power, lean }: PoweredProps & { lean: number }) => {
+  const count = Math.round(lerp(4, SPARK_COUNT, power));
 
-      return (
-        <motion.span
-          key={index}
-          className="absolute"
-          style={{
-            width: elongated ? size * 3.5 : size,
-            height: size,
-            // Centred with margins, not a translate class: the keyframes below
-            // own the transform outright and would overwrite one.
-            marginLeft: -size / 2,
-            marginTop: -size / 2,
-            borderRadius: size,
-            background: index % 2 ? `rgb(${VIOLET})` : "#ffffff",
-            boxShadow: `0 0 ${6 + size}px rgba(${VIOLET},0.85)`,
-            rotate: (heading * 180) / Math.PI,
-          }}
-          initial={{ x: 0, y: 0, opacity: 1, scale: 1 }}
-          animate={{
-            x: [0, dx, dx * 1.25],
-            y: [0, dy, dy + 210],
-            opacity: [1, 1, 0],
-            scale: [1, 1, 0.35],
-          }}
-          transition={{
-            duration: 1.05 + scatter(index, 9) * 0.45,
-            times: [0, 0.45, 1],
-            ease: ["easeOut", "easeIn"],
-          }}
-        />
-      );
-    })}
-  </>
-);
+  return (
+    <>
+      {Array.from({ length: count }, (_, index) => {
+        const heading =
+          ((lean + FAN_FROM + scatter(index, 6) * (FAN_TO - FAN_FROM)) * Math.PI) / 180;
+        const speed = lerp(50, 90, power) + scatter(index, 7) * lerp(90, 320, power);
+        const dx = Math.cos(heading) * speed;
+        const dy = Math.sin(heading) * speed;
+        const size = 3 + scatter(index, 8) * 4;
+        const elongated = index % 3 === 0;
+
+        return (
+          <motion.span
+            key={index}
+            className="absolute"
+            style={{
+              width: elongated ? size * 3.5 : size,
+              height: size,
+              // Centred with margins, not a translate class: the keyframes below
+              // own the transform outright and would overwrite one.
+              marginLeft: -size / 2,
+              marginTop: -size / 2,
+              borderRadius: size,
+              background: index % 2 ? `rgb(${VIOLET})` : "#ffffff",
+              boxShadow: `0 0 ${6 + size}px rgba(${VIOLET},0.85)`,
+              rotate: (heading * 180) / Math.PI,
+            }}
+            initial={{ x: 0, y: 0, opacity: 1, scale: 1 }}
+            animate={{
+              x: [0, dx, dx * 1.25],
+              y: [0, dy, dy + 210],
+              opacity: [1, 1, 0],
+              scale: [1, 1, 0.35],
+            }}
+            transition={{
+              duration: 1.05 + scatter(index, 9) * 0.45,
+              times: [0, 0.45, 1],
+              ease: ["easeOut", "easeIn"],
+            }}
+          />
+        );
+      })}
+    </>
+  );
+};

--- a/content/effort-picker/curl-fanfare.tsx
+++ b/content/effort-picker/curl-fanfare.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { motion } from "motion/react";
+
+import type { EffortTheme } from "./effort-theme";
+
+import { CARD_PADDING, KNOB_SIZE, TRACK_TRAVEL } from "./effort-scale";
+import { EFFORT_THEMES, notchX } from "./effort-theme";
+
+/**
+ * The payoff for ten seconds of curling in front of a webcam.
+ *
+ * Everything here fires from one point — the notch the dial actually landed on —
+ * so the celebration is *about the number you earned*, not a generic confetti
+ * cannon bolted to the card. Land on Light and the fireworks go off over on the
+ * left, next to nothing; land on Ultra and they go off at the end of the track.
+ * Same show, different address, and the address is the joke.
+ *
+ * Layers, in the order the eye reads them: the fill ignites and a bloom opens at
+ * the notch, an anamorphic flare rips along the track, streaks fan out, rings
+ * chase them, and the whole thing rains sparks over the card while the rim
+ * lights up.
+ */
+
+/** How long the layer stays mounted, in ms. The card tears it down after this —
+ * every animation below has finished and faded by then. */
+export const FANFARE_MS = 1700;
+
+const STREAK_COUNT = 15;
+const SPARK_COUNT = 30;
+/** Streaks start this far out from the notch instead of at it. Fifteen bars
+ * converging on one pixel screen-blend themselves into a solid white disc — the
+ * hollow core is what keeps the burst reading as separate rays. */
+const STREAK_GAP = 22;
+/**
+ * The burst fires from the notch, which sits on the bottom edge of the card — so
+ * a tidy 360° fan throws most of itself straight into an edge and is gone. Rays
+ * and sparks are aimed across this arc instead: centred straight up, wide enough
+ * to reach both top corners. Screen degrees, where -90 is up and 0 is right.
+ */
+const FAN_FROM = -205;
+const FAN_TO = 25;
+/** ...and the whole arc leans away from whichever end of the track it landed on,
+ * by up to this many degrees. A Light take fires from the left edge and a Max one
+ * from the right; without the lean, half of either burst is clipped on the frame
+ * it's born. */
+const FAN_LEAN = 30;
+
+/** violet-400, as raw channels — half of these colours are built inside template
+ * strings for `boxShadow` and gradients, where a Tailwind class can't reach. */
+const VIOLET = "167,139,250";
+
+/**
+ * Deterministic 0..1 from an index. The spray has to look scattered without
+ * being *actually* random: `Math.random()` would reshuffle every particle on
+ * every re-render, and the card re-renders plenty while this is on screen.
+ */
+const scatter = (index: number, salt: number) => {
+  const value = Math.sin(index * 12.9898 + salt * 78.233) * 43758.5453;
+  return value - Math.floor(value);
+};
+
+type CurlFanfareProps = {
+  /** The level the take rounded down to — the show's origin point. */
+  level: number;
+  theme: EffortTheme;
+};
+
+export const CurlFanfare = ({ level, theme }: CurlFanfareProps) => {
+  const tokens = EFFORT_THEMES[theme];
+  const landedX = notchX(theme, level);
+  // Card coordinates, not track coordinates: the fanfare covers the whole card,
+  // so the notch has to be re-expressed against the card's own padding box. The
+  // track sits flush in that box, which makes this the knob's centre.
+  const anchorLeft = CARD_PADDING + KNOB_SIZE / 2 + landedX;
+  const anchorBottom = CARD_PADDING + KNOB_SIZE / 2;
+  const lean = (0.5 - landedX / TRACK_TRAVEL) * 2 * FAN_LEAN;
+
+  return (
+    <>
+      {/* The card's own edge, lit. Unclipped, so the outer bloom escapes the
+          popover the way a real light source would. */}
+      <motion.span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 rounded-[inherit]"
+        style={{
+          boxShadow: `inset 0 0 0 2px rgba(196,181,253,0.7), inset 0 0 40px rgba(${VIOLET},0.28), 0 0 60px rgba(139,92,246,0.45)`,
+        }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: [0, 1, 0] }}
+        transition={{ duration: 1.3, times: [0, 0.1, 1], ease: "easeOut" }}
+      />
+
+      {/* Everything with a trajectory lives in here, clipped to the card. Sparks
+          that outlive the card's edge should die at it — a firework that leaks
+          out of the popover reads as a rendering bug, not a flourish.
+
+          `isolate` matters as much as the clip: every layer below blends screen,
+          and without an isolation group they blend against the whole card —
+          including the verdict's `backdrop-blur` panel, which Chrome composites
+          in a different pass. Left un-isolated they stack into one flat white
+          disc over the camera. Isolated, they screen against each other and the
+          group lands on the card as ordinary alpha. */}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit] isolate"
+      >
+        {/* The fill charges: a hot band runs the length of everything the take
+            earned, arriving at the notch just as the knob commits to it. */}
+        <span
+          className="absolute overflow-hidden"
+          style={{
+            left: CARD_PADDING,
+            bottom: CARD_PADDING + (KNOB_SIZE - tokens.troughHeight) / 2,
+            width: landedX + KNOB_SIZE / 2,
+            height: tokens.troughHeight,
+            borderRadius: tokens.troughRadius,
+          }}
+        >
+          <motion.span
+            className="absolute inset-y-0 w-1/2 mix-blend-screen"
+            style={{
+              backgroundImage:
+                "linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 55%, rgba(255,255,255,0) 100%)",
+            }}
+            initial={{ x: "-130%" }}
+            animate={{ x: "320%" }}
+            transition={{ duration: 0.65, ease: "easeOut" }}
+          />
+        </span>
+
+        <Glare />
+
+        {/* Zero-sized anchor at the notch. Everything below centres on it the
+            same way the per-rep `Sparks` do — position once, then only ever
+            animate transforms. */}
+        <span className="absolute size-0" style={{ left: anchorLeft, bottom: anchorBottom }}>
+          <Bloom />
+          <Flare />
+          <Streaks lean={lean} />
+          <Rings />
+          <SparkSpray lean={lean} />
+        </span>
+      </span>
+    </>
+  );
+};
+
+/**
+ * The soft glow under everything else. Deliberately smaller than the card: an
+ * earlier pass sized it to swallow the whole popover and the result was a white
+ * rectangle with a knob in it. The celebration has to stay *local to the notch*,
+ * or the card stops being a card for half a second.
+ */
+const Bloom = () => (
+  <motion.span
+    className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full"
+    style={{
+      width: 440,
+      height: 440,
+      backgroundImage: `radial-gradient(circle, rgba(${VIOLET},0.55) 0%, rgba(139,92,246,0.3) 30%, rgba(109,40,217,0.14) 52%, transparent 72%)`,
+    }}
+    initial={{ scale: 0.12, opacity: 0 }}
+    animate={{ scale: [0.12, 1, 1.25], opacity: [0, 1, 0] }}
+    transition={{ duration: 1.15, times: [0, 0.16, 1], ease: "easeOut" }}
+  />
+);
+
+/** The anamorphic streak along the track axis. One horizontal bar does more for
+ * "this is a light source" than any amount of radial spray. */
+const Flare = () => (
+  <motion.span
+    className="absolute mix-blend-screen"
+    style={{
+      width: 480,
+      height: 4,
+      x: -240,
+      y: -2,
+      borderRadius: 4,
+      backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(${VIOLET},0.7) 30%, rgba(255,255,255,0.95) 50%, rgba(${VIOLET},0.7) 70%, rgba(255,255,255,0) 100%)`,
+      filter: "blur(1.5px)",
+    }}
+    initial={{ scaleX: 0.05, scaleY: 0.4, opacity: 0 }}
+    animate={{ scaleX: [0.05, 1, 1.1], scaleY: [0.4, 1, 0.3], opacity: [0, 0.9, 0] }}
+    transition={{ duration: 0.95, times: [0, 0.14, 1], ease: "easeOut" }}
+  />
+);
+
+/**
+ * A single bar of glare raked across the whole card, once. The notch burst is
+ * pinned to one corner by definition; this is the only layer that touches every
+ * part of the card, and it's what makes the celebration feel card-sized rather
+ * than corner-sized.
+ */
+const Glare = () => (
+  <motion.span
+    className="absolute -top-1/4 h-[150%] w-28 mix-blend-screen"
+    style={{
+      left: -120,
+      rotate: 14,
+      backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(221,214,254,0.22) 45%, rgba(255,255,255,0.34) 55%, rgba(255,255,255,0) 100%)`,
+    }}
+    initial={{ x: 0, opacity: 0 }}
+    animate={{ x: [0, 660], opacity: [0, 1, 1, 0] }}
+    transition={{ duration: 0.7, times: [0, 0.15, 0.7, 1], ease: "easeOut" }}
+  />
+);
+
+/**
+ * The fan of glowing streaks. Each bar hangs off a wrapper that does nothing but
+ * rotate about the notch — the split is what lets the bar sit `STREAK_GAP` out
+ * along its own axis. Rotating a pre-offset bar directly would swing the offset
+ * with it, since motion applies translation before rotation.
+ *
+ * No `filter: blur()` on these, deliberately. Fifteen filtered layers all
+ * appearing on the same frame promote fifteen render surfaces at once, and the
+ * first composited frame of the burst can come out as one white flash. The soft
+ * edge is baked into the gradient instead, which costs nothing.
+ */
+const Streaks = ({ lean }: { lean: number }) => (
+  <>
+    {Array.from({ length: STREAK_COUNT }, (_, index) => {
+      const angle =
+        lean + FAN_FROM + ((index + scatter(index, 1) * 0.7) / STREAK_COUNT) * (FAN_TO - FAN_FROM);
+      const length = 110 + scatter(index, 2) * 230;
+      const thickness = 2 + scatter(index, 3) * 3.5;
+
+      return (
+        <span
+          key={index}
+          className="absolute size-0"
+          style={{ rotate: `${angle}deg`, transformOrigin: "0% 0%" }}
+        >
+          <motion.span
+            className="absolute mix-blend-screen"
+            style={{
+              left: STREAK_GAP,
+              top: -thickness / 2,
+              width: length,
+              height: thickness,
+              borderRadius: thickness,
+              transformOrigin: "0% 50%",
+              backgroundImage: `linear-gradient(90deg, rgba(255,255,255,0.95) 0%, rgba(${VIOLET},0.85) 30%, rgba(139,92,246,0.35) 65%, rgba(139,92,246,0) 100%)`,
+            }}
+            initial={{ scaleX: 0, opacity: 0 }}
+            animate={{ scaleX: [0, 1, 1], opacity: [0, 1, 0] }}
+            transition={{
+              duration: 0.75 + scatter(index, 4) * 0.5,
+              times: [0, 0.24, 1],
+              ease: "easeOut",
+              delay: scatter(index, 5) * 0.12,
+            }}
+          />
+        </span>
+      );
+    })}
+  </>
+);
+
+/** Three shockwaves, staggered. Width and height are animated rather than
+ * `scale` so the stroke stays hairline-thin as the ring grows — a scaled border
+ * fattens up and stops reading as a shockwave. */
+const Rings = () => (
+  <>
+    {[0, 0.1, 0.22].map((delay, index) => (
+      <motion.span
+        key={delay}
+        className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-violet-200/70 mix-blend-screen"
+        style={{ boxShadow: `0 0 22px rgba(${VIOLET},0.55)` }}
+        initial={{ width: 20, height: 20, opacity: 0 }}
+        animate={{ width: 280 + index * 110, height: 280 + index * 110, opacity: [0, 0.8, 0] }}
+        transition={{ duration: 0.95, delay, times: [0, 0.1, 1], ease: [0.16, 1, 0.3, 1] }}
+      />
+    ))}
+  </>
+);
+
+/** Ballistic sparks: a fan launched up and out of the notch, then dropped. The
+ * two-segment easing is what sells it — `easeOut` on the way up, `easeIn` on the
+ * way down, because a firework that decelerates into the floor looks like it's
+ * being lowered on a wire. */
+const SparkSpray = ({ lean }: { lean: number }) => (
+  <>
+    {Array.from({ length: SPARK_COUNT }, (_, index) => {
+      const heading = ((lean + FAN_FROM + scatter(index, 6) * (FAN_TO - FAN_FROM)) * Math.PI) / 180;
+      const speed = 90 + scatter(index, 7) * 320;
+      const dx = Math.cos(heading) * speed;
+      const dy = Math.sin(heading) * speed;
+      const size = 3 + scatter(index, 8) * 4;
+      const elongated = index % 3 === 0;
+
+      return (
+        <motion.span
+          key={index}
+          className="absolute"
+          style={{
+            width: elongated ? size * 3.5 : size,
+            height: size,
+            // Centred with margins, not a translate class: the keyframes below
+            // own the transform outright and would overwrite one.
+            marginLeft: -size / 2,
+            marginTop: -size / 2,
+            borderRadius: size,
+            background: index % 2 ? `rgb(${VIOLET})` : "#ffffff",
+            boxShadow: `0 0 ${6 + size}px rgba(${VIOLET},0.85)`,
+            rotate: (heading * 180) / Math.PI,
+          }}
+          initial={{ x: 0, y: 0, opacity: 1, scale: 1 }}
+          animate={{
+            x: [0, dx, dx * 1.25],
+            y: [0, dy, dy + 210],
+            opacity: [1, 1, 0],
+            scale: [1, 1, 0.35],
+          }}
+          transition={{
+            duration: 1.05 + scatter(index, 9) * 0.45,
+            times: [0, 0.45, 1],
+            ease: ["easeOut", "easeIn"],
+          }}
+        />
+      );
+    })}
+  </>
+);

--- a/content/effort-picker/curl-track.tsx
+++ b/content/effort-picker/curl-track.tsx
@@ -8,7 +8,7 @@ import type { MotionValue } from "motion/react";
 
 import type { EffortTheme } from "./effort-theme";
 
-import { CurlFanfare, FANFARE_MS } from "./curl-fanfare";
+import { CurlFanfare, fanfarePower, FANFARE_MS } from "./curl-fanfare";
 import { DialTrough, knobBoxStyle, KnobSkin, Sparks } from "./effort-dial";
 import { clamp, KNOB_SIZE, percentToX, TRACK_WIDTH } from "./effort-scale";
 import { EFFORT_THEMES, labelAt, nearestLevel, notchX } from "./effort-theme";
@@ -31,6 +31,11 @@ const KNOB_PUMP = { type: "spring", stiffness: 700, damping: 18 } as const;
 /** Looser than the per-rep pump and thrown from much further out: the landing
  * kick is the one the whole take has been building to. */
 const KNOB_SLAM = { type: "spring", stiffness: 420, damping: 11 } as const;
+
+const lerp = (from: number, to: number, t: number) => from + (to - from) * t;
+/** Power below which the verdict keeps its halo and drops the rest of its
+ * ceremony. Four curls is a result, not an occasion. */
+const SUNBURST_FLOOR = 0.45;
 
 type CountdownCount = 3 | 2 | 1;
 type Burst = { id: number; percent: number };
@@ -214,9 +219,16 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
         // in a single frame, so the spring inherits a velocity of ~33/s. Left to
         // pick that up, this one underdamped spring blew the knob to 36× its own
         // size — a white disc wider than the card, for about a fifth of a second.
-        knobScale.set(1.55);
+        //
+        // How hard it lands is the take's own doing: at the bottom of the track
+        // this is a nudge and the card barely moves, at the top it's a slam.
+        const power = fanfarePower(theme, level);
+        knobScale.set(lerp(1.16, 1.55, power));
         void animate(knobScale, 1, { ...KNOB_SLAM, velocity: 0 });
-        void animate(cardPop, [1, 1.035, 0.995, 1], { duration: 0.6, ease: "easeOut" });
+        void animate(cardPop, [1, lerp(1.008, 1.035, power), 0.997, 1], {
+          duration: 0.6,
+          ease: "easeOut",
+        });
         setCelebrating(true);
       }
       onDone(true);
@@ -239,6 +251,10 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
   }, [scoldNonce, cardShake]);
 
   const landedLabel = take.status === "complete" ? labelAt(theme, take.level) : null;
+  // How much of the ceremony the take earned, 0 at the bottom notch and 1 at the
+  // top. Everything the card itself does for the landing is scaled by it, the
+  // same way `CurlFanfare` scales the fireworks.
+  const power = take.status === "complete" ? fanfarePower(theme, take.level) : 0;
   const live = take.status === "lifting";
 
   return (
@@ -353,39 +369,52 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
                           verdict keeps a light on it for as long as it's up. */}
                       <motion.span
                         aria-hidden
-                        className="absolute top-1/2 left-1/2 size-64 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
+                        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
                         style={{
+                          width: lerp(140, 256, power),
+                          height: lerp(140, 256, power),
                           backgroundImage:
                             "radial-gradient(circle, rgba(167,139,250,0.75) 0%, rgba(139,92,246,0.4) 34%, rgba(109,40,217,0.16) 56%, transparent 72%)",
                         }}
                         initial={{ scale: 0.25, opacity: 0 }}
-                        animate={{ scale: [0.25, 1.15, 1], opacity: [0, 1, 0.65] }}
+                        animate={{
+                          scale: [0.25, 1.15, 1],
+                          opacity: [0, lerp(0.45, 1, power), lerp(0.3, 0.65, power)],
+                        }}
                         transition={{ duration: 0.85, times: [0, 0.35, 1], ease: "easeOut" }}
                       />
                       {/* A sunburst, turning slowly. It's a repeating conic
                           gradient masked back to a disc — twelve wedges of light
                           behind the word, which is the cheapest way to make a
-                          static label look like it's radiating. */}
-                      <motion.span
-                        aria-hidden
-                        className="absolute top-1/2 left-1/2 size-72 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
-                        style={{
-                          backgroundImage:
-                            "repeating-conic-gradient(rgba(196,181,253,0.34) 0deg 8deg, transparent 8deg 30deg)",
-                          maskImage:
-                            "radial-gradient(circle, #000 0%, rgba(0,0,0,0.55) 42%, transparent 70%)",
-                        }}
-                        initial={{ scale: 0.4, opacity: 0, rotate: -14 }}
-                        animate={{ scale: 1, opacity: [0, 0.9, 0.35], rotate: 12 }}
-                        transition={{ duration: 2.4, times: [0, 0.14, 1], ease: "easeOut" }}
-                      />
-                      {[0, 0.13].map((delay) => (
+                          static label look like it's radiating. Reserved for the
+                          top half of the track: a Light take gets the halo and
+                          nothing to stand in front of. */}
+                      {power >= SUNBURST_FLOOR && (
+                        <motion.span
+                          aria-hidden
+                          className="absolute top-1/2 left-1/2 size-72 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
+                          style={{
+                            backgroundImage:
+                              "repeating-conic-gradient(rgba(196,181,253,0.34) 0deg 8deg, transparent 8deg 30deg)",
+                            maskImage:
+                              "radial-gradient(circle, #000 0%, rgba(0,0,0,0.55) 42%, transparent 70%)",
+                          }}
+                          initial={{ scale: 0.4, opacity: 0, rotate: -14 }}
+                          animate={{ scale: 1, opacity: [0, power, power * 0.4], rotate: 12 }}
+                          transition={{ duration: 2.4, times: [0, 0.14, 1], ease: "easeOut" }}
+                        />
+                      )}
+                      {[0, 0.13].slice(0, power >= SUNBURST_FLOOR ? 2 : 1).map((delay) => (
                         <motion.span
                           key={delay}
                           aria-hidden
                           className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-violet-200/70 shadow-[0_0_24px_rgba(167,139,250,0.6)]"
                           initial={{ width: 40, height: 40, opacity: 0 }}
-                          animate={{ width: 300, height: 300, opacity: [0, 0.85, 0] }}
+                          animate={{
+                            width: lerp(150, 300, power),
+                            height: lerp(150, 300, power),
+                            opacity: [0, lerp(0.5, 0.85, power), 0],
+                          }}
                           transition={{
                             duration: 1,
                             delay,
@@ -413,8 +442,14 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
                       }}
                       // White, not violet: the sunburst behind it is violet and
                       // bright, and the word has to stay the lightest thing on
-                      // the card or the ceremony swallows the verdict.
-                      className="text-[30px] leading-none font-semibold text-white drop-shadow-[0_0_26px_rgba(139,92,246,0.95)]"
+                      // the card or the ceremony swallows the verdict. It grows
+                      // with the take as well — Ultra should be a headline and
+                      // Light shouldn't be.
+                      style={{
+                        fontSize: lerp(20, 30, power),
+                        filter: `drop-shadow(0 0 ${lerp(12, 26, power)}px rgba(139,92,246,0.95))`,
+                      }}
+                      className="leading-none font-semibold text-white"
                     >
                       {landedLabel}
                     </motion.span>
@@ -458,7 +493,7 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
             aria-hidden
             className="pointer-events-none absolute inset-0 bg-violet-50 mix-blend-screen"
             initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0.42, 0] }}
+            animate={{ opacity: [0, lerp(0.1, 0.42, power), 0] }}
             transition={{ duration: 0.55, times: [0, 0.07, 1], ease: "easeOut" }}
           />
         )}

--- a/content/effort-picker/curl-track.tsx
+++ b/content/effort-picker/curl-track.tsx
@@ -8,6 +8,7 @@ import type { MotionValue } from "motion/react";
 
 import type { EffortTheme } from "./effort-theme";
 
+import { CurlFanfare, FANFARE_MS } from "./curl-fanfare";
 import { DialTrough, knobBoxStyle, KnobSkin, Sparks } from "./effort-dial";
 import { clamp, KNOB_SIZE, percentToX, TRACK_WIDTH } from "./effort-scale";
 import { EFFORT_THEMES, labelAt, nearestLevel, notchX } from "./effort-theme";
@@ -27,6 +28,9 @@ const DRAIN_PER_SEC = 10;
 
 const COMMIT_SPRING = { type: "spring", stiffness: 180, damping: 18 } as const;
 const KNOB_PUMP = { type: "spring", stiffness: 700, damping: 18 } as const;
+/** Looser than the per-rep pump and thrown from much further out: the landing
+ * kick is the one the whole take has been building to. */
+const KNOB_SLAM = { type: "spring", stiffness: 420, damping: 11 } as const;
 
 type CountdownCount = 3 | 2 | 1;
 type Burst = { id: number; percent: number };
@@ -66,9 +70,12 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
   const [reps, setReps] = useState(0);
   const [bursts, setBursts] = useState<Burst[]>([]);
   const [scolding, setScolding] = useState(false);
+  /** The landing fireworks, mounted for exactly as long as they burn. */
+  const [celebrating, setCelebrating] = useState(false);
   const reduceMotion = useReducedMotion();
 
   const cardShake = useMotionValue(0);
+  const cardPop = useMotionValue(1);
   const knobScale = useMotionValue(1);
   const timerScale = useMotionValue(1);
   const timerRef = useRef<HTMLSpanElement>(null);
@@ -123,12 +130,24 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
     setReps(0);
     setBursts([]);
     setScolding(false);
+    setCelebrating(false);
     setTake({ status: "arming" });
     onDone(false);
     timerScale.set(1);
+    cardPop.set(1);
+    knobScale.set(1);
     if (reduceMotionRef.current) knobX.set(0);
     else void animate(knobX, 0, COMMIT_SPRING);
-  }, [knobX, onDone, timerScale]);
+  }, [knobX, onDone, timerScale, cardPop, knobScale]);
+
+  // The fireworks tear themselves down. Nothing in `CurlFanfare` loops, so the
+  // only reason to keep three dozen animated spans mounted past their last
+  // frame would be forgetting to unmount them.
+  useEffect(() => {
+    if (!celebrating) return;
+    const timer = window.setTimeout(() => setCelebrating(false), FANFARE_MS);
+    return () => window.clearTimeout(timer);
+  }, [celebrating]);
 
   // The count-in waits for the camera to actually find a pair of arms. Counting
   // "3, 2, 1" at an empty room and then scoring the empty room is a bug wearing
@@ -183,16 +202,29 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
         current.status === "lifting" ? { status: "complete", level } : current,
       );
       if (reduceMotionRef.current) knobX.set(notchX(theme, level));
-      // The drain writes knobX every frame, so the value arrives at the commit
-      // carrying real velocity — a spring that inherits it hurls the knob clean
-      // off the end of the track. The take is over; it starts from rest.
-      else void animate(knobX, notchX(theme, level), { ...COMMIT_SPRING, velocity: 0 });
+      else {
+        // The drain writes knobX every frame, so the value arrives at the commit
+        // carrying real velocity — a spring that inherits it hurls the knob clean
+        // off the end of the track. The take is over; it starts from rest.
+        void animate(knobX, notchX(theme, level), { ...COMMIT_SPRING, velocity: 0 });
+        // The knob doesn't just arrive at the notch, it lands on it: a slam the
+        // card feels, with the fireworks going off from the point of impact.
+        // `velocity: 0` for the same reason the commit above needs it, and then
+        // some: a `set()` one tick before an `animate()` reads as a jump of 0.55
+        // in a single frame, so the spring inherits a velocity of ~33/s. Left to
+        // pick that up, this one underdamped spring blew the knob to 36× its own
+        // size — a white disc wider than the card, for about a fifth of a second.
+        knobScale.set(1.55);
+        void animate(knobScale, 1, { ...KNOB_SLAM, velocity: 0 });
+        void animate(cardPop, [1, 1.035, 0.995, 1], { duration: 0.6, ease: "easeOut" });
+        setCelebrating(true);
+      }
       onDone(true);
     };
 
     frame = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(frame);
-  }, [take.status, knobX, timerScale, onDone, theme]);
+  }, [take.status, knobX, knobScale, cardPop, timerScale, onDone, theme]);
 
   // Walking out mid-set is not a thing you get to do.
   const firstNonce = useRef(scoldNonce);
@@ -210,7 +242,10 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
   const live = take.status === "lifting";
 
   return (
-    <motion.div style={{ x: cardShake }} className={`relative p-5 ${EFFORT_THEMES[theme].card}`}>
+    <motion.div
+      style={{ x: cardShake, scale: cardPop }}
+      className={`relative p-5 ${EFFORT_THEMES[theme].card}`}
+    >
       <div className="mb-4 flex h-8 items-center justify-between gap-3">
         <p className="text-[15px] font-medium text-neutral-100">Reasoning effort</p>
 
@@ -310,22 +345,81 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
                       ? { duration: 0.1 }
                       : { type: "spring", stiffness: 320, damping: 20 }
                   }
-                  className="relative flex flex-col items-center gap-1"
+                  className="relative flex flex-col items-center gap-1.5"
                 >
                   {!reduceMotion && (
-                    <motion.span
-                      aria-hidden
-                      className="absolute size-3 rounded-full bg-violet-500/60 blur-md"
-                      initial={{ scale: 0.4, opacity: 0.9 }}
-                      animate={{ scale: [0.4, 14, 11], opacity: [0.9, 0.35, 0.18] }}
-                      transition={{ duration: 0.9, ease: "easeOut" }}
-                    />
+                    <>
+                      {/* A halo that blows open and then stays, dimmed — the
+                          verdict keeps a light on it for as long as it's up. */}
+                      <motion.span
+                        aria-hidden
+                        className="absolute top-1/2 left-1/2 size-64 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
+                        style={{
+                          backgroundImage:
+                            "radial-gradient(circle, rgba(167,139,250,0.75) 0%, rgba(139,92,246,0.4) 34%, rgba(109,40,217,0.16) 56%, transparent 72%)",
+                        }}
+                        initial={{ scale: 0.25, opacity: 0 }}
+                        animate={{ scale: [0.25, 1.15, 1], opacity: [0, 1, 0.65] }}
+                        transition={{ duration: 0.85, times: [0, 0.35, 1], ease: "easeOut" }}
+                      />
+                      {/* A sunburst, turning slowly. It's a repeating conic
+                          gradient masked back to a disc — twelve wedges of light
+                          behind the word, which is the cheapest way to make a
+                          static label look like it's radiating. */}
+                      <motion.span
+                        aria-hidden
+                        className="absolute top-1/2 left-1/2 size-72 -translate-x-1/2 -translate-y-1/2 rounded-full mix-blend-screen"
+                        style={{
+                          backgroundImage:
+                            "repeating-conic-gradient(rgba(196,181,253,0.34) 0deg 8deg, transparent 8deg 30deg)",
+                          maskImage:
+                            "radial-gradient(circle, #000 0%, rgba(0,0,0,0.55) 42%, transparent 70%)",
+                        }}
+                        initial={{ scale: 0.4, opacity: 0, rotate: -14 }}
+                        animate={{ scale: 1, opacity: [0, 0.9, 0.35], rotate: 12 }}
+                        transition={{ duration: 2.4, times: [0, 0.14, 1], ease: "easeOut" }}
+                      />
+                      {[0, 0.13].map((delay) => (
+                        <motion.span
+                          key={delay}
+                          aria-hidden
+                          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-violet-200/70 shadow-[0_0_24px_rgba(167,139,250,0.6)]"
+                          initial={{ width: 40, height: 40, opacity: 0 }}
+                          animate={{ width: 300, height: 300, opacity: [0, 0.85, 0] }}
+                          transition={{
+                            duration: 1,
+                            delay,
+                            times: [0, 0.12, 1],
+                            ease: [0.16, 1, 0.3, 1],
+                          }}
+                        />
+                      ))}
+                    </>
                   )}
-                  <p className="relative flex items-baseline gap-1.5 text-[17px] font-medium">
-                    <span className="text-neutral-400">Landed on</span>
-                    <span className="text-violet-300">{landedLabel}</span>
+                  <p className="relative flex flex-col items-center gap-0.5">
+                    <span className="text-[13px] tracking-wide text-neutral-400 uppercase">
+                      Landed on
+                    </span>
+                    {/* The word itself gets the pop, a beat behind the card's:
+                        the fireworks announce it, then it arrives. */}
+                    <motion.span
+                      initial={reduceMotion ? false : { scale: 0.6, opacity: 0 }}
+                      animate={{ scale: 1, opacity: 1 }}
+                      transition={{
+                        type: "spring",
+                        stiffness: 520,
+                        damping: 13,
+                        delay: reduceMotion ? 0 : 0.08,
+                      }}
+                      // White, not violet: the sunburst behind it is violet and
+                      // bright, and the word has to stay the lightest thing on
+                      // the card or the ceremony swallows the verdict.
+                      className="text-[30px] leading-none font-semibold text-white drop-shadow-[0_0_26px_rgba(139,92,246,0.95)]"
+                    >
+                      {landedLabel}
+                    </motion.span>
                   </p>
-                  <p className="relative text-[13px] tabular-nums text-neutral-500">
+                  <p className="relative text-[13px] tabular-nums text-neutral-400">
                     {reps} {reps === 1 ? "curl" : "curls"} in 10 seconds
                   </p>
                 </motion.div>
@@ -356,6 +450,18 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
             </motion.div>
           )}
         </AnimatePresence>
+
+        {/* Flashbulb. The camera has been pointed at you for ten seconds; when
+            the clock stops, it takes the photo. */}
+        {celebrating && (
+          <motion.span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-violet-50 mix-blend-screen"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0.42, 0] }}
+            transition={{ duration: 0.55, times: [0, 0.07, 1], ease: "easeOut" }}
+          />
+        )}
       </div>
 
       <div className="relative" style={{ width: TRACK_WIDTH, height: KNOB_SIZE }}>
@@ -376,6 +482,14 @@ export const CurlCard = ({ knobX, theme, scoldNonce, onDone }: CurlCardProps) =>
           <KnobSkin theme={theme} />
         </motion.div>
       </div>
+
+      {/* Last child, and deliberately: the fanfare is lit from in front of the
+          card, so it goes over the camera, the verdict and the dial alike. Every
+          layer of it blends screen, which brightens what's underneath instead of
+          hiding it — the word you earned stays legible through the fireworks. */}
+      {celebrating && take.status === "complete" && (
+        <CurlFanfare level={take.level} theme={theme} />
+      )}
     </motion.div>
   );
 };


### PR DESCRIPTION
Landing a level in the **curls** variant was a small violet blur behind three words. Ten seconds of curling in front of a webcam deserved more than that.

## The show is scaled to the take

Everything runs off one number — `power`, how far up the track you actually got. Handing out identical fireworks for four curls and for sixteen would undo the only thing the card is measuring, so **Light gets a shrug and Ultra gets the works**:

| | Light | High | Ultra |
| :-- | :-- | :-- | :-- |
| rays / sparks | 3 / 4, short | ~9 / ~17 | 15 / 30, long |
| shockwaves | 1, small | 2 | 3, large |
| glare rake across the card | — | faint | full |
| sunburst behind the verdict | — | yes | yes, bright |
| rim flash, flashbulb, knob slam, card kick | barely | mid | full |
| the word itself | 20px | 25px | 30px, big glow |

Rays shorten as they thin out — cutting only the count leaves three full-length spears, which reads as a broken burst rather than a small one. The fill ignition is the one layer left unscaled: it *is* the scale, since there's barely any fill to run down at the bottom of the track.

## Where it fires

From **one point — the notch the take actually landed on**. Land on Light and the small burst goes off at the left end of an almost-empty track; land on Ultra and the big one goes off at the far end. The arc also leans away from whichever end it's nearest, so a burst born on the frame edge doesn't throw half of itself off-card.

New `content/effort-picker/curl-fanfare.tsx` owns the layer: the fill ignites, a bloom opens at the notch, an anamorphic flare rips along the track axis, rays fan out, shockwaves chase them, sparks arc up over the card and fall, a bar of glare rakes across the whole card, and the rim lights up. Alongside it, in `curl-track.tsx`: the camera takes a flashbulb, the knob slams into the notch, the card kicks, and the verdict lands as a big white word on a slowly turning sunburst.

Reduced motion is unchanged: the knob snaps to the notch and none of this mounts.

## Three things that had to be got right

**The layer is clipped to the card and `isolate`d.** Un-isolated, the screen-blend stack composites against the verdict's `backdrop-blur` panel and collapses into a single flat white disc over the camera.

**Rays start `STREAK_GAP` out from the notch rather than at it.** Fifteen bars converging on one pixel screen-blend themselves into a solid white disc — the hollow core is what keeps the burst reading as separate rays.

**The knob's landing spring takes `velocity: 0`.** A `set()` one tick before an `animate()` reads as a jump of 0.55 in a single frame, and the underdamped slam spring inherited ~33/s of it: the knob blew up to **36× its own size**, a white disc wider than the card, for about a fifth of a second. This is the same trap the `knobX` commit spring directly below it already documents.

## Verification

- `pnpm typecheck` · `pnpm build` green; `pnpm lint` adds no new warnings from these files.
- `pnpm format` is green on both changed files. It fails on `AGENTS.md`, which is **pre-existing on `main`** and untouched here.
- Driven headlessly with `agent-browser` against `/preview-frame/effort-picker`. The pose hook needs a webcam this container doesn't have, so reps were driven by a temporary stub for the runtime passes and the real `usePoseCurls` was restored before each commit — the final tree was re-checked in the browser (camera-denied state renders cleanly, no console errors).
- Timeline stepped frame by frame via paused `document.getAnimations()` and pixel-sampled at the card's right and bottom edges across `t = 60…1300ms`: nothing paints outside the card at any point.
- Landings checked at the bottom, middle and top of the track, on both themes (ChatGPT's five notches and Claude's six).