### PR TITLE
feat: add editorial-charts — an ink-on-paper chart set drawn by TanStack Charts

### DIFF
--- a/content/editorial-charts/charts/dot-waffle.tsx
+++ b/content/editorial-charts/charts/dot-waffle.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { defineChart, dot } from "@tanstack/charts";
+import { motion } from "@tanstack/charts/motion";
+import { Chart } from "@tanstack/charts/react/core";
+import { scaleLinear } from "@tanstack/charts/scales/linear";
+import { useMemo } from "react";
+
+import type { MixRow } from "../lib/data";
+import { SPRING } from "../lib/tokens";
+
+const renderer = motion({ transition: SPRING, initial: "always" });
+
+type Cell = { id: string; col: number; row: number; plan: string };
+
+// A hundred dots, one per percent. Cells fill left to right, top to bottom;
+// keys carry the plan so a shifted percent pops out and back in.
+export const DotWaffle = ({
+  mix,
+  reveal,
+  size,
+  ladder,
+}: {
+  mix: MixRow[];
+  /** 0 → 1 entrance progress; the grid inks in dot by dot. */
+  reveal: number;
+  size: number;
+  ladder: readonly string[];
+}) => {
+  const revealed = Math.min(100, Math.floor(reveal * 101));
+
+  const definition = useMemo(() => {
+    const bounds: number[] = [];
+    let acc = 0;
+    for (const m of mix) {
+      acc += m.share;
+      bounds.push(acc);
+    }
+    const cells: Cell[] = Array.from({ length: revealed }, (_, i) => {
+      const slot = bounds.findIndex((b) => i < b);
+      const plan = mix[slot === -1 ? mix.length - 1 : slot]?.plan ?? "";
+      // Fill left → right, top → bottom, so the darkest plan starts where the
+      // legend starts reading.
+      return { id: `${i}:${plan}`, col: i % 10, row: 9 - Math.floor(i / 10), plan };
+    });
+    return defineChart({
+      guides: false,
+      margin: 0,
+      color: { domain: mix.map((m) => m.plan), range: [...ladder] },
+      marks: [
+        dot(cells, {
+          x: "col",
+          y: "row",
+          key: "id",
+          color: "plan",
+          r: size / 30,
+        }),
+      ],
+      scales: {
+        x: { scale: scaleLinear().domain([-0.65, 9.65]) },
+        y: { scale: scaleLinear().domain([-0.65, 9.65]) },
+      },
+    });
+  }, [mix, revealed, size, ladder]);
+
+  return (
+    <Chart
+      definition={definition}
+      renderer={renderer}
+      width={size}
+      height={size}
+      ariaLabel="New accounts by plan, one dot per percent"
+    />
+  );
+};

--- a/content/editorial-charts/charts/hairline-line.tsx
+++ b/content/editorial-charts/charts/hairline-line.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { defineChart, dot, lineY, text, tickX } from "@tanstack/charts";
+import { motion } from "@tanstack/charts/motion";
+import { Chart } from "@tanstack/charts/react/core";
+import { scaleLinear } from "@tanstack/charts/scales/linear";
+import { useMemo } from "react";
+
+import type { DayRow } from "../lib/data";
+import { FAINT, INK, MUTED, PAPER, SPRING } from "../lib/tokens";
+
+const renderer = motion({ transition: SPRING, initial: "always" });
+
+// One dot = one day, hollow = weekend, barcode floor keeps the calendar
+// honest. Days land dot by dot; the hairline threads them once the month is
+// complete.
+export const HairlineLine = ({
+  days,
+  reveal,
+  yMax,
+  height,
+  initialWidth,
+}: {
+  days: DayRow[];
+  /** 0 → 1 entrance progress; days land left to right as it advances. */
+  reveal: number;
+  yMax: number;
+  height: number;
+  initialWidth: number;
+}) => {
+  const revealed = Math.min(days.length, Math.floor(reveal * (days.length + 1)));
+
+  const definition = useMemo(() => {
+    const shown = days.slice(0, revealed);
+    const complete = revealed >= days.length;
+    const weekdays = shown.filter((d) => !d.weekend);
+    const weekends = shown.filter((d) => d.weekend);
+    const peak = days.reduce((a, b) => (b.value > a.value ? b : a));
+    const last = days[days.length - 1];
+    // Two callouts crowd each other when the peak already sits near day 30.
+    const callouts = !complete
+      ? []
+      : last === undefined || last.day === peak.day || peak.day >= 26
+        ? [peak]
+        : [peak, last];
+    return defineChart({
+      guides: false,
+      margin: 0,
+      motion: { path: "morph" },
+      marks: [
+        tickX(shown, {
+          x: "day",
+          y: () => 0,
+          length: 8,
+          key: "day",
+          stroke: FAINT,
+          strokeWidth: 1,
+        }),
+        ...(complete
+          ? [
+              lineY(days, {
+                x: "day",
+                y: "value",
+                key: "day",
+                stroke: INK,
+                strokeWidth: 1.25,
+              }),
+            ]
+          : []),
+        dot(weekdays, {
+          id: "weekday-dots",
+          x: "day",
+          y: "value",
+          key: "day",
+          r: 2.4,
+          fill: INK,
+        }),
+        dot(weekends, {
+          id: "weekend-dots",
+          x: "day",
+          y: "value",
+          key: "day",
+          r: 2.6,
+          fill: PAPER,
+          stroke: INK,
+          strokeWidth: 1.1,
+        }),
+        text(callouts, {
+          x: "day",
+          y: "value",
+          key: "day",
+          text: (d) => `${d.value}`,
+          anchor: (d) => (d.day >= 27 ? "end" : "middle"),
+          dx: (d) => (d.day >= 27 ? 3 : 0),
+          dy: -13,
+          fill: INK,
+          fontSize: 11.5,
+          fontWeight: 800,
+        }),
+      ],
+      scales: {
+        x: { scale: scaleLinear().domain([1, 30]) },
+        y: { scale: scaleLinear().domain([0, yMax * 1.2]) },
+      },
+    });
+  }, [days, revealed, yMax]);
+
+  return (
+    <div>
+      <Chart
+        definition={definition}
+        renderer={renderer}
+        height={height}
+        initialWidth={initialWidth}
+        ariaLabel="Daily sign-ups over thirty days"
+      />
+      <div
+        className="relative h-5 pt-1.5 text-[9px] font-semibold tracking-[0.09em]"
+        style={{ color: MUTED }}
+      >
+        <span className="absolute left-0">DAY 1</span>
+        <span className="absolute left-[48.3%] -translate-x-1/2">DAY 15</span>
+        <span className="absolute right-0">DAY 30</span>
+      </div>
+    </div>
+  );
+};

--- a/content/editorial-charts/charts/rung-bars.tsx
+++ b/content/editorial-charts/charts/rung-bars.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { defineChart, text, tickY } from "@tanstack/charts";
+import { motion } from "@tanstack/charts/motion";
+import { Chart } from "@tanstack/charts/react/core";
+import { scaleLinear } from "@tanstack/charts/scales/linear";
+import { scalePoint } from "@tanstack/charts/scales/point";
+import { useMemo } from "react";
+
+import type { PlanRow } from "../lib/data";
+import { INK, MUTED, SPRING } from "../lib/tokens";
+
+const renderer = motion({ transition: SPRING, initial: "always" });
+
+// One rung = $2k of MRR. The bar is a ladder you can count.
+const RUNG = 2;
+
+type Rung = { id: string; plan: string; y: number; fifth: boolean };
+
+export const RungBars = ({
+  plans,
+  reveal,
+  height,
+  initialWidth,
+}: {
+  plans: PlanRow[];
+  /** 0 → 1 entrance progress; rungs climb in as it advances. */
+  reveal: number;
+  height: number;
+  initialWidth: number;
+}) => {
+  const totalRungs = plans.reduce((sum, p) => sum + Math.round(p.value / RUNG), 0);
+  const revealed = Math.min(totalRungs, Math.floor(reveal * (totalRungs + 1)));
+
+  const definition = useMemo(() => {
+    const rungs: Rung[] = plans.flatMap((p) =>
+      Array.from({ length: Math.round(p.value / RUNG) }, (_, i) => ({
+        id: `${p.plan}-${i}`,
+        plan: p.plan,
+        y: (i + 1) * RUNG,
+        fifth: (i + 1) % 5 === 0,
+      })),
+    );
+    // The ladder climbs column by column, rung by rung.
+    const shown = rungs.slice(0, revealed);
+    const done = new Map<string, number>();
+    for (const r of shown) done.set(r.plan, (done.get(r.plan) ?? 0) + 1);
+    const labeled = plans.filter((p) => (done.get(p.plan) ?? 0) >= Math.round(p.value / RUNG));
+    const top = Math.max(...plans.map((p) => p.value)) * 1.36;
+    return defineChart({
+      guides: false,
+      margin: 0,
+      marks: [
+        tickY(shown, {
+          x: "plan",
+          y: "y",
+          span: 0.5,
+          key: "id",
+          stroke: (d) => (d.fifth ? INK : "rgba(27,27,25,0.55)"),
+          strokeWidth: 1.2,
+        }),
+        text(labeled, {
+          x: "plan",
+          y: "value",
+          key: "plan",
+          text: (d) => `${d.value}`,
+          dy: -13,
+          fill: INK,
+          fontSize: 12,
+          fontWeight: 800,
+        }),
+      ],
+      scales: {
+        // Fixed domains keep columns and headroom still while marks enter.
+        x: {
+          scale: scalePoint<string>()
+            .domain(plans.map((p) => p.plan))
+            .padding(0.5),
+        },
+        y: { scale: scaleLinear().domain([0, top]) },
+      },
+    });
+  }, [plans, revealed]);
+
+  return (
+    <div>
+      <Chart
+        definition={definition}
+        renderer={renderer}
+        height={height}
+        initialWidth={initialWidth}
+        ariaLabel="Monthly recurring revenue by plan, one rung per two thousand dollars"
+      />
+      <div className="flex" style={{ color: MUTED }}>
+        {plans.map((p) => (
+          <span
+            key={p.plan}
+            className="flex-1 pt-1.5 text-center text-[9px] font-semibold tracking-[0.09em]"
+          >
+            {p.plan}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/content/editorial-charts/charts/tick-ring.tsx
+++ b/content/editorial-charts/charts/tick-ring.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { defineChart, vector } from "@tanstack/charts";
+import { motion } from "@tanstack/charts/motion";
+import { Chart } from "@tanstack/charts/react/core";
+import { scaleLinear } from "@tanstack/charts/scales/linear";
+import { useMemo } from "react";
+
+import type { ChannelRow } from "../lib/data";
+import { SPRING } from "../lib/tokens";
+
+const renderer = motion({ transition: SPRING, initial: "always" });
+
+type RingTick = {
+  id: number;
+  x: number;
+  y: number;
+  rotate: number;
+  channel: string;
+  major: boolean;
+};
+
+// 100 radial dashes, one per percent, read clockwise from noon. The reveal
+// sweeps the dial once; after that each scene twists it a few degrees so the
+// update itself is visible motion.
+export const TickRing = ({
+  channels,
+  reveal,
+  size,
+  twist,
+  ladder,
+}: {
+  channels: ChannelRow[];
+  /** 0 → 1 entrance progress; the dial sweeps clockwise as it advances. */
+  reveal: number;
+  size: number;
+  twist: number;
+  ladder: readonly string[];
+}) => {
+  const revealed = Math.min(100, Math.floor(reveal * 101));
+
+  const definition = useMemo(() => {
+    const bounds: number[] = [];
+    let acc = 0;
+    for (const c of channels) {
+      acc += c.share;
+      bounds.push(acc);
+    }
+    const shade = new Map(channels.map((c, i) => [c.channel, ladder[i % ladder.length]]));
+    const ticks: RingTick[] = Array.from({ length: revealed }, (_, i) => {
+      const deg = i * 3.6 + twist;
+      const rad = (deg * Math.PI) / 180;
+      const slot = bounds.findIndex((b) => i < b);
+      const row = channels[slot === -1 ? channels.length - 1 : slot];
+      return {
+        id: i,
+        x: Math.sin(rad),
+        y: Math.cos(rad),
+        rotate: deg + 180,
+        channel: row?.channel ?? "",
+        major: i % 10 === 0,
+      };
+    });
+    return defineChart({
+      guides: false,
+      margin: 0,
+      marks: [
+        vector(ticks, {
+          x: "x",
+          y: "y",
+          rotate: "rotate",
+          anchor: "start",
+          length: (d) => (d.major ? 26 : 18),
+          headLength: 0,
+          key: "id",
+          stroke: (d) => shade.get(d.channel) ?? ladder[0] ?? "#f1f0ec",
+          strokeWidth: 2.4,
+        }),
+      ],
+      scales: {
+        x: { scale: scaleLinear().domain([-1, 1]) },
+        y: { scale: scaleLinear().domain([-1, 1]) },
+      },
+    });
+  }, [channels, revealed, twist, ladder]);
+
+  return (
+    <Chart
+      definition={definition}
+      renderer={renderer}
+      width={size}
+      height={size}
+      ariaLabel="Sessions by acquisition channel, one tick per percent"
+    />
+  );
+};

--- a/content/editorial-charts/editorial-charts.tsx
+++ b/content/editorial-charts/editorial-charts.tsx
@@ -12,18 +12,22 @@ import { DARK, FAINT, INK, LADDER, MUTED, PAPER } from "./lib/tokens";
 const CYCLE_MS = 4600;
 
 const useCountUp = (target: number, ms = 950) => {
-  const [shown, setShown] = useState(target);
-  const prev = useRef(0);
+  // Starts at 0 (matching the not-yet-inked charts around it) and always
+  // resumes from the last painted value, so neither SSR nor a Strict Mode
+  // remount can flash the final count or skip the entrance.
+  const [shown, setShown] = useState(0);
+  const painted = useRef(0);
   useEffect(() => {
-    const from = prev.current;
-    prev.current = target;
+    const from = painted.current;
     if (from === target) return;
     let raf = 0;
     const t0 = performance.now();
     const step = (t: number) => {
       const p = Math.min(1, (t - t0) / ms);
       const eased = 1 - (1 - p) ** 3;
-      setShown(Math.round(from + (target - from) * eased));
+      const value = Math.round(from + (target - from) * eased);
+      painted.current = value;
+      setShown(value);
       if (p < 1) raf = requestAnimationFrame(step);
     };
     raf = requestAnimationFrame(step);

--- a/content/editorial-charts/editorial-charts.tsx
+++ b/content/editorial-charts/editorial-charts.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { DotWaffle } from "./charts/dot-waffle";
+import { HairlineLine } from "./charts/hairline-line";
+import { RungBars } from "./charts/rung-bars";
+import { TickRing } from "./charts/tick-ring";
+import { DAY_MAX, SCENES } from "./lib/data";
+import { DARK, FAINT, INK, LADDER, MUTED, PAPER } from "./lib/tokens";
+
+const CYCLE_MS = 4600;
+
+const useCountUp = (target: number, ms = 950) => {
+  const [shown, setShown] = useState(target);
+  const prev = useRef(0);
+  useEffect(() => {
+    const from = prev.current;
+    prev.current = target;
+    if (from === target) return;
+    let raf = 0;
+    const t0 = performance.now();
+    const step = (t: number) => {
+      const p = Math.min(1, (t - t0) / ms);
+      const eased = 1 - (1 - p) ** 3;
+      setShown(Math.round(from + (target - from) * eased));
+      if (p < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [target, ms]);
+  return shown;
+};
+
+// Entrance clock: 0 → 1 over `ms`, driving how much of each chart is inked.
+const useReveal = (active: boolean, ms: number) => {
+  const [progress, setProgress] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    let raf = 0;
+    const t0 = performance.now();
+    const step = (t: number) => {
+      const p = Math.min(1, (t - t0) / ms);
+      setProgress(p);
+      if (p < 1) raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [active, ms]);
+  return progress;
+};
+
+const Kicker = ({ children, dark }: { children: string; dark?: boolean }) => (
+  <span
+    className="inline-block rounded-full border border-dashed px-2.5 py-0.5 text-[8.5px] font-semibold tracking-[0.14em]"
+    style={{
+      color: dark ? DARK.muted : MUTED,
+      borderColor: dark ? DARK.faint : FAINT,
+    }}
+  >
+    {children}
+  </span>
+);
+
+const CardHead = ({
+  kicker,
+  title,
+  sub,
+  dark,
+}: {
+  kicker: string;
+  title: string;
+  sub: string;
+  dark?: boolean;
+}) => (
+  <div>
+    <Kicker dark={dark}>{kicker}</Kicker>
+    <h2
+      className="mt-2 text-[16.5px] font-bold tracking-[-0.02em]"
+      style={{ color: dark ? DARK.ink : INK }}
+    >
+      {title}
+    </h2>
+    <p className="mt-0.5 text-[11.5px]" style={{ color: dark ? DARK.muted : MUTED }}>
+      {sub}
+    </p>
+  </div>
+);
+
+const SourceRow = ({ children, dark }: { children: string; dark?: boolean }) => (
+  <p
+    className="mt-auto pt-3 text-[9px] font-medium tracking-[0.08em]"
+    style={{ color: dark ? DARK.faint : FAINT }}
+  >
+    {children}
+  </p>
+);
+
+export const EditorialCharts = () => {
+  const [scene, setScene] = useState(0);
+  // Charts mount after first paint so every visitor gets the full staggered
+  // entrance instead of a server-rendered final state.
+  const [inked, setInked] = useState(false);
+  useEffect(() => {
+    setInked(true);
+    const t = setInterval(() => setScene((s) => (s + 1) % SCENES.length), CYCLE_MS);
+    return () => clearInterval(t);
+  }, []);
+
+  const reveal = useReveal(inked, 1500);
+  const s = SCENES[scene] ?? SCENES[0]!;
+  const sessions = useCountUp(s.sessions);
+
+  return (
+    <div
+      className="w-[1080px] rounded-[28px] px-9 pt-7 pb-5 shadow-[0_40px_90px_-30px_rgba(0,0,0,0.55)] [font-family:Inter,ui-sans-serif,system-ui,sans-serif]"
+      style={{ backgroundColor: PAPER, color: INK }}
+    >
+      {/* Masthead */}
+      <div className="flex items-baseline justify-between pb-4">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-[19px] font-bold tracking-[-0.02em]">The quarter, drawn in ink</h1>
+          <span className="text-[11.5px]" style={{ color: MUTED }}>
+            four marks, one grammar, one spring
+          </span>
+        </div>
+        <div className="flex gap-3 text-[11px] font-bold tracking-[0.06em]">
+          {SCENES.map((q, i) => (
+            <span
+              key={q.quarter}
+              className="transition-colors duration-500"
+              style={{
+                color: i === scene ? INK : FAINT,
+                borderBottom: i === scene ? `2px solid ${INK}` : "2px solid transparent",
+              }}
+            >
+              {q.quarter}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-x-9 gap-y-5">
+        {/* Rung bars */}
+        <section className="flex min-h-[298px] flex-col">
+          <CardHead
+            kicker="RUNG BARS · BILLING"
+            title="Revenue by plan, rung by rung"
+            sub="one rung = $2k of MRR · the bar is a ladder you can count"
+          />
+          <div className="mt-3 h-[204px]">
+            {inked && <RungBars plans={s.plans} reveal={reveal} height={182} initialWidth={480} />}
+          </div>
+          <SourceRow>TICK MARKS ON A POINT SCALE · STAGGERED SPRING ENTRANCE</SourceRow>
+        </section>
+
+        {/* Tick ring — the dark card */}
+        <section
+          className="flex min-h-[298px] flex-col rounded-[20px] px-6 pt-5 pb-4"
+          style={{ backgroundColor: DARK.bg }}
+        >
+          <CardHead
+            dark
+            kicker="TICK RING · ACQUISITION"
+            title="Where the sessions come from"
+            sub="one tick = 1% · reads clockwise from noon · the dial twists each quarter"
+          />
+          <div className="relative mx-auto mt-1 size-[198px]">
+            {inked && (
+              <TickRing
+                channels={s.channels}
+                reveal={reveal}
+                size={198}
+                twist={scene * 14}
+                ladder={DARK.ladder}
+              />
+            )}
+            <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+              <span
+                className="text-[30px] font-extrabold tracking-[-0.02em] tabular-nums"
+                style={{ color: DARK.ink }}
+              >
+                {(sessions / 1000).toFixed(1)}k
+              </span>
+              <span
+                className="text-[8.5px] font-semibold tracking-[0.14em]"
+                style={{ color: DARK.muted }}
+              >
+                SESSIONS
+              </span>
+            </div>
+            {s.channels.map((c, i) => {
+              // Clockwise from noon: channel order sweeps right side first.
+              const spots = [
+                "left-full top-3 ml-3",
+                "left-full bottom-3 ml-3",
+                "right-full bottom-3 mr-3 text-right",
+                "right-full top-3 mr-3 text-right",
+              ] as const;
+              return (
+                <div
+                  key={c.channel}
+                  className={`absolute w-24 text-[9px] font-semibold tracking-[0.1em] ${spots[i % 4]}`}
+                  style={{ color: DARK.ladder[i % DARK.ladder.length] }}
+                >
+                  {c.channel}
+                  <span className="block text-[13px] font-extrabold tabular-nums tracking-normal">
+                    {c.share}%
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+          <SourceRow dark>100 VECTOR MARKS · ONE SHADE PER CHANNEL · SPRUNG TWIST</SourceRow>
+        </section>
+
+        {/* Hairline line */}
+        <section className="flex min-h-[286px] flex-col">
+          <CardHead
+            kicker="HAIRLINE LINE · GROWTH"
+            title="Thirty days of sign-ups"
+            sub="one dot = one day · hollow = weekend · the floor is a barcode of days"
+          />
+          <div className="mt-3 h-[184px]">
+            {inked && (
+              <HairlineLine
+                days={s.days}
+                reveal={reveal}
+                yMax={DAY_MAX}
+                height={158}
+                initialWidth={480}
+              />
+            )}
+          </div>
+          <SourceRow>LINE + DOT + TEXT MARKS · PATH MORPHS BETWEEN QUARTERS</SourceRow>
+        </section>
+
+        {/* Dot waffle */}
+        <section className="flex min-h-[286px] flex-col">
+          <CardHead
+            kicker="DOT WAFFLE · PLAN MIX"
+            title="What the new accounts pick"
+            sub="one dot = 1% of new accounts · a moved percent pops out and back in"
+          />
+          <div className="mt-2 flex items-center gap-8">
+            <div className="size-[182px]">
+              {inked && <DotWaffle mix={s.mix} reveal={reveal} size={182} ladder={LADDER} />}
+            </div>
+            <div className="flex flex-col gap-2.5">
+              {s.mix.map((m, i) => (
+                <div key={m.plan} className="flex items-center gap-2.5">
+                  <span
+                    className="size-2.5 rounded-full"
+                    style={{ backgroundColor: LADDER[i % LADDER.length] }}
+                  />
+                  <span
+                    className="w-16 text-[9px] font-semibold tracking-[0.1em]"
+                    style={{ color: MUTED }}
+                  >
+                    {m.plan}
+                  </span>
+                  <span className="text-[13px] font-extrabold tabular-nums">{m.share}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <SourceRow>DOT MARKS + ORDINAL COLOR SCALE · KEYS CARRY THE PLAN</SourceRow>
+        </section>
+      </div>
+
+      <p
+        className="pt-4 text-center text-[9px] font-medium tracking-[0.08em]"
+        style={{ color: FAINT }}
+      >
+        DEMO DATA · DRAWN BY TANSTACK CHARTS · SPRINGS AND STAGGER BY ITS MOTION RENDERER
+      </p>
+    </div>
+  );
+};

--- a/content/editorial-charts/lib/data.ts
+++ b/content/editorial-charts/lib/data.ts
@@ -1,0 +1,109 @@
+// Three quarters of a fictional product, cycled by the set. Deterministic on
+// purpose — a refresh must draw the exact same page.
+
+export type PlanRow = { plan: string; value: number };
+export type DayRow = { day: number; value: number; weekend: boolean };
+export type ChannelRow = { channel: string; share: number };
+export type MixRow = { plan: string; share: number };
+
+export type Scene = {
+  quarter: string;
+  plans: PlanRow[];
+  days: DayRow[];
+  channels: ChannelRow[];
+  sessions: number;
+  mix: MixRow[];
+};
+
+const hash = (n: number) => {
+  let x = (n + 0x9e3779b9) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x45d9f3b) >>> 0;
+  return ((x ^ (x >>> 16)) >>> 0) / 0xffffffff;
+};
+
+const days = (seed: number, base: number, slope: number): DayRow[] =>
+  Array.from({ length: 30 }, (_, i) => {
+    const weekend = i % 7 === 5 || i % 7 === 6;
+    const wiggle = (hash(seed * 1000 + i) - 0.5) * 16;
+    const value = Math.max(6, Math.round(base + i * slope + wiggle - (weekend ? 11 : 0)));
+    return { day: i + 1, value, weekend };
+  });
+
+export const SCENES: Scene[] = [
+  {
+    quarter: "Q1",
+    plans: [
+      { plan: "FREE", value: 38 },
+      { plan: "STARTER", value: 27 },
+      { plan: "PRO", value: 22 },
+      { plan: "TEAM", value: 16 },
+      { plan: "SCALE", value: 10 },
+    ],
+    days: days(1, 34, 0.9),
+    channels: [
+      { channel: "ORGANIC", share: 37 },
+      { channel: "REFERRAL", share: 21 },
+      { channel: "SOCIAL", share: 14 },
+      { channel: "PAID", share: 28 },
+    ],
+    sessions: 41_800,
+    mix: [
+      { plan: "FREE", share: 46 },
+      { plan: "STARTER", share: 27 },
+      { plan: "PRO", share: 17 },
+      { plan: "TEAM", share: 10 },
+    ],
+  },
+  {
+    quarter: "Q2",
+    plans: [
+      { plan: "FREE", value: 44 },
+      { plan: "STARTER", value: 31 },
+      { plan: "PRO", value: 26 },
+      { plan: "TEAM", value: 21 },
+      { plan: "SCALE", value: 13 },
+    ],
+    days: days(2, 42, 1.15),
+    channels: [
+      { channel: "ORGANIC", share: 41 },
+      { channel: "REFERRAL", share: 23 },
+      { channel: "SOCIAL", share: 12 },
+      { channel: "PAID", share: 24 },
+    ],
+    sessions: 48_200,
+    mix: [
+      { plan: "FREE", share: 41 },
+      { plan: "STARTER", share: 29 },
+      { plan: "PRO", share: 19 },
+      { plan: "TEAM", share: 11 },
+    ],
+  },
+  {
+    quarter: "Q3",
+    plans: [
+      { plan: "FREE", value: 52 },
+      { plan: "STARTER", value: 36 },
+      { plan: "PRO", value: 30 },
+      { plan: "TEAM", value: 24 },
+      { plan: "SCALE", value: 18 },
+    ],
+    days: days(3, 52, 1.4),
+    channels: [
+      { channel: "ORGANIC", share: 46 },
+      { channel: "REFERRAL", share: 24 },
+      { channel: "SOCIAL", share: 11 },
+      { channel: "PAID", share: 19 },
+    ],
+    sessions: 56_400,
+    mix: [
+      { plan: "FREE", share: 34 },
+      { plan: "STARTER", share: 31 },
+      { plan: "PRO", share: 22 },
+      { plan: "TEAM", share: 13 },
+    ],
+  },
+];
+
+// Shared y ceiling so the line visibly climbs across quarters.
+export const DAY_MAX = Math.max(...SCENES.flatMap((s) => s.days.map((d) => d.value)));

--- a/content/editorial-charts/lib/data.ts
+++ b/content/editorial-charts/lib/data.ts
@@ -8,6 +8,8 @@ export type MixRow = { plan: string; share: number };
 
 export type Scene = {
   quarter: string;
+  /** $k MRR per plan. Keep every value divisible by 2: one rung = $2k, and the
+   * rung-bars ladder must count exactly to its label. */
   plans: PlanRow[];
   days: DayRow[];
   channels: ChannelRow[];
@@ -35,7 +37,7 @@ export const SCENES: Scene[] = [
     quarter: "Q1",
     plans: [
       { plan: "FREE", value: 38 },
-      { plan: "STARTER", value: 27 },
+      { plan: "STARTER", value: 28 },
       { plan: "PRO", value: 22 },
       { plan: "TEAM", value: 16 },
       { plan: "SCALE", value: 10 },
@@ -59,10 +61,10 @@ export const SCENES: Scene[] = [
     quarter: "Q2",
     plans: [
       { plan: "FREE", value: 44 },
-      { plan: "STARTER", value: 31 },
+      { plan: "STARTER", value: 32 },
       { plan: "PRO", value: 26 },
-      { plan: "TEAM", value: 21 },
-      { plan: "SCALE", value: 13 },
+      { plan: "TEAM", value: 20 },
+      { plan: "SCALE", value: 14 },
     ],
     days: days(2, 42, 1.15),
     channels: [

--- a/content/editorial-charts/lib/tokens.ts
+++ b/content/editorial-charts/lib/tokens.ts
@@ -1,0 +1,28 @@
+// Editorial mono tokens — paper ground, charcoal ink, lightness IS the data.
+// Inspired by print-editorial data graphics; values are our own.
+
+export const PAPER = "#f1f0ec";
+export const INK = "#1b1b19";
+export const MUTED = "#8b8a84";
+export const FAINT = "#c2c1bb";
+export const HAIR = "#dbdad3";
+
+// Ink ladder for multi-series work: most important = darkest.
+export const LADDER = ["#1b1b19", "#4a4943", "#8b8a84", "#aeada7", "#d0cfc9"] as const;
+
+// Dark card: ink becomes paper, ladder runs bright → dim.
+export const DARK = {
+  bg: "#1b1b19",
+  ink: "#f1f0ec",
+  muted: "#8b8a84",
+  faint: "#4c4b45",
+  ladder: ["#f1f0ec", "#c7c6be", "#93928b", "#5c5b54"] as const,
+};
+
+// One spring for the whole set — quick in, no bounce to speak of.
+export const SPRING = {
+  type: "spring",
+  stiffness: 170,
+  damping: 22,
+  mass: 1,
+} as const;

--- a/content/editorial-charts/meta.json
+++ b/content/editorial-charts/meta.json
@@ -1,0 +1,6 @@
+{
+  "name": "Editorial Charts",
+  "description": "A four-card editorial chart set — rung bars, a hairline dot-line, a tick-ring dial, and a dot waffle — drawn ink-on-paper by TanStack Charts, with spring-staggered entrances and quarterly data that morphs on a loop.",
+  "tags": ["charts", "minimal", "business"],
+  "defaultSize": "full"
+}

--- a/content/editorial-charts/package.json
+++ b/content/editorial-charts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@uicapsule/editorial-charts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo dist node_modules"
+  },
+  "dependencies": {
+    "@tanstack/charts": "^0.16.0",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:"
+  }
+}

--- a/content/editorial-charts/preview.tsx
+++ b/content/editorial-charts/preview.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { EditorialCharts } from "./editorial-charts";
+
+const Preview = () => {
+  return (
+    <main className="flex h-dvh items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_50%_25%,#26272b_0%,#141518_50%,#08090b_100%)] px-5">
+      <div className="origin-center scale-[0.94]">
+        <EditorialCharts />
+      </div>
+    </main>
+  );
+};
+
+export default Preview;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
         version: 2.0.1(next@16.3.3(@babel/core@7.29.7)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       better-auth:
         specifier: 'catalog:'
-        version: 1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@babel/core@7.29.7)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -481,6 +481,25 @@ importers:
       motion:
         specifier: ^13.1.1
         version: 13.1.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.8
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.8(react@19.2.8)
+    devDependencies:
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.5(@types/react@19.2.18)
+
+  content/editorial-charts:
+    dependencies:
+      '@tanstack/charts':
+        specifier: ^0.16.0
+        version: 0.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -1156,7 +1175,7 @@ importers:
         version: link:../db
       better-auth:
         specifier: 'catalog:'
-        version: 1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@babel/core@7.29.7)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     devDependencies:
       '@kyh/tsconfig':
         specifier: 'catalog:'
@@ -3251,6 +3270,50 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || >=4.0.0 || insiders'
 
+  '@tanstack/charts@0.16.0':
+    resolution: {integrity: sha512-adG4sVaWjSqGsp/8YU5q7AjoYoPaivVseDjWWcV4osKemfTHnGFlPqlymxbhWxk1BF3p5Rewgqs4BlgZAXve8g==}
+    peerDependencies:
+      '@angular/core': '>=19'
+      '@angular/platform-browser': '>=19'
+      alpinejs: '>=3.15'
+      lit: '>=3.1.3'
+      octane: ^0.1.13
+      preact: '>=10'
+      react: ^19.0.0
+      react-dom: ^19.0.0
+      react-native: ^0.86.0
+      react-native-svg: '>=15.15.4 <16'
+      solid-js: '>=1.8'
+      svelte: ^5.20.0
+      vue: '>=3.5'
+    peerDependenciesMeta:
+      '@angular/core':
+        optional: true
+      '@angular/platform-browser':
+        optional: true
+      alpinejs:
+        optional: true
+      lit:
+        optional: true
+      octane:
+        optional: true
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      react-native-svg:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   '@tanstack/query-core@5.102.8':
     resolution: {integrity: sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==}
 
@@ -3323,8 +3386,35 @@ packages:
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-path@1.0.11':
+    resolution: {integrity: sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-sankey@0.12.5':
+    resolution: {integrity: sha512-/3RZSew0cLAtzGQ+C89hq/Rp3H20QJuVRSqFy6RKLe7E0B8kd2iOS1oBsodrgds4PcNVpqWhdUEng/SHvBcJ6Q==}
+
+  '@types/d3-shape@1.3.12':
+    resolution: {integrity: sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q==}
+
+  '@types/d3-shape@3.2.0':
+    resolution: {integrity: sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==}
+
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.5':
     resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
@@ -3855,6 +3945,115 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hexbin@0.2.2:
+    resolution: {integrity: sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
@@ -3901,6 +4100,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -4340,6 +4542,13 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.6.0:
     resolution: {integrity: sha512-SY8PiLbaC3EC0rocJjJkYInMVDm8X6gEcoILEWVmUInxLycY18Ug7pZHKVjVmUTf6Eo+CZ2p+bu1Lz1ku/k1rg==}
@@ -5090,6 +5299,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
   rou3@0.9.2:
     resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
@@ -7137,6 +7349,31 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.3
 
+  '@tanstack/charts@0.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@types/d3-force': 3.0.10
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-sankey': 0.12.5
+      '@types/d3-shape': 3.2.0
+      d3-array: 3.2.4
+      d3-brush: 3.0.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-force: 3.0.0
+      d3-geo: 3.1.1
+      d3-hexbin: 0.2.2
+      d3-hierarchy: 3.1.2
+      d3-sankey: 0.12.3
+      d3-scale: 4.0.2
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-zoom: 3.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   '@tanstack/query-core@5.102.8': {}
 
   '@tanstack/react-query@5.102.8(react@19.2.8)':
@@ -7199,7 +7436,33 @@ snapshots:
 
   '@tweenjs/tween.js@23.1.3': {}
 
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-path@1.0.11': {}
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-sankey@0.12.5':
+    dependencies:
+      '@types/d3-shape': 1.3.12
+
+  '@types/d3-shape@1.3.12':
+    dependencies:
+      '@types/d3-path': 1.0.11
+
+  '@types/d3-shape@3.2.0':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
   '@types/draco3d@1.4.10': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.5':
     dependencies:
@@ -7377,7 +7640,7 @@ snapshots:
 
   baseline-browser-mapping@2.11.20: {}
 
-  better-auth@1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  better-auth@1.7.2(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))(next@16.3.3(@babel/core@7.29.7)(@types/node@26.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.5.2))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2)
       '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.5.2))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@libsql/client@0.17.4)(kysely@0.29.5))
@@ -7585,6 +7848,117 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hexbin@0.2.2: {}
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   date-fns@4.4.0: {}
 
   debounce-fn@4.0.0:
@@ -7611,6 +7985,10 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   depd@2.0.0: {}
 
@@ -8050,6 +8428,10 @@ snapshots:
       resolve-from: 4.0.0
 
   inherits@2.0.4: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.6.0: {}
 
@@ -8723,6 +9105,8 @@ snapshots:
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  robust-predicates@3.0.3: {}
 
   rou3@0.9.2: {}
 


### PR DESCRIPTION
A set of four chart components staged as one editorial page — the visual grammar of print data graphics (paper ground, charcoal ink, hairlines, countable marks, lightness-as-data), rendered entirely by [TanStack Charts](https://github.com/TanStack/charts) (`@tanstack/charts` 0.16). Rung bars are `tickY` marks on a point scale (one rung = $2k, the bar is a ladder you can count); the sign-ups card is `lineY` + solid/hollow `dot` marks with a `tickX` barcode floor; the dark dial is 100 `vector` marks swept clockwise from noon; the waffle is 100 `dot` marks through an ordinal color scale of ink shades. All four share one spring via the optional motion renderer.

Motion story: a reveal clock inks each chart in after mount — ladders climb rung by rung, the dial sweeps, days land dot by dot and the hairline threads them once the month completes. Then three quarters of demo data cycle every 4.6s: paths morph, rung labels ride their springs, the dial twists a few degrees, shifted waffle percents pop out and back in (their keys carry the plan), and the session counter counts up. Data is deterministic — a refresh draws the exact same page.

One note for the record: the visual language is an homage to lieflat-charts (PolyForm Noncommercial); everything here — code, tokens, data — is written from scratch against TanStack Charts' API, no code or assets were copied.

## Preview recording

![editorial-charts](https://raw.githubusercontent.com/kyh/uicapsule/kyh/pr-preview-assets/editorial-charts.gif)

_Recorded locally from [`/preview-frame/editorial-charts`](https://uicapsule-git-claude-chart-components-tanstack-t4bexq-kyh-io.vercel.app/preview-frame/editorial-charts)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp9dK6pH3gePKckkFKHbVF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wp9dK6pH3gePKckkFKHbVF)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `editorial-charts` content set — an ink-on-paper four-chart dashboard (rung bars, a hairline dot-line, a tick-ring dial, and a dot waffle) drawn entirely by `@tanstack/charts` and its motion renderer. The session counter now runs from 0 and resumes from the last painted value instead of flashing the final count on first paint or skipping the entrance on a Strict Mode remount.

**New Features**
- Charts ink in after mount, then cycle three quarters of deterministic demo data every 4.6s with in-place morphing.
- Rung bar labels and waffle dots carry plan keys, so changed values pop out and back in.
- Plan values stay divisible by the $2k rung unit so each ladder counts exactly to its label.

**Dependencies**
- Adds `@tanstack/charts` 0.16 and its d3 dependency tree to the lockfile.

<sup>Written for commit f626a65b988e0b1a41b7f43bdf216998315e07d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

