### PR TITLE
chore: migrate to cn for Tailwind class merging

### DIFF
--- a/content/expanding-header-menu/expanding-header-menu.tsx
+++ b/content/expanding-header-menu/expanding-header-menu.tsx
@@ -1,4 +1,4 @@
-import { cn } from "cnfast";
+import { cn } from "cn";
 import {
   ChevronDown,
   ChevronRight,

--- a/content/expanding-header-menu/package.json
+++ b/content/expanding-header-menu/package.json
@@ -10,7 +10,7 @@
     "clean": "git clean -xdf .cache .turbo dist node_modules"
   },
   "dependencies": {
-    "cnfast": "^0.1.0",
+    "cn": "^0.2.3",
     "lucide-react": "^1.35.0",
     "motion": "^13.1.1",
     "react": "catalog:",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,7 +21,7 @@
     "@shikijs/transformers": "^4.4.3",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
-    "cnfast": "^0.1.0",
+    "cn": "^0.2.3",
     "date-fns": "^4.4.0",
     "lucide-react": "^1.35.0",
     "motion": "^13.1.1",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,1 +1,1 @@
-export { cn } from "cnfast";
+export { cn } from "cn";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,9 +572,9 @@ importers:
 
   content/expanding-header-menu:
     dependencies:
-      cnfast:
-        specifier: ^0.1.0
-        version: 0.1.0
+      cn:
+        specifier: ^0.2.3
+        version: 0.2.3
       lucide-react:
         specifier: ^1.35.0
         version: 1.35.0(react@19.2.8)
@@ -846,7 +846,7 @@ importers:
         version: 19.2.18
       '@types/react-dom':
         specifier: 'catalog:'
-        version: 19.2.4(@types/react@19.2.18)
+        version: 19.2.5(@types/react@19.2.18)
 
   content/lookbook-camera:
     dependencies:
@@ -1263,9 +1263,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      cnfast:
-        specifier: ^0.1.0
-        version: 0.1.0
+      cn:
+        specifier: ^0.2.3
+        version: 0.2.3
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -3875,8 +3875,9 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  cnfast@0.1.0:
-    resolution: {integrity: sha512-rH0jBKeLkVrK7NsZ5Ba2l7WdMBmm1k0FMpABeXUU1PgTUxbz3261gEuCSsrYuXo4BwAe3yCcIbQ93YyS52lOGQ==}
+  cn@0.2.3:
+    resolution: {integrity: sha512-z1S2v7FdtqcoXQzJWqNPBJ3KPG1or9FlefB0x+Eu8322BMmCSSVqzeI7itNj/6YRjyendnlWDJnKQkBhukT3fg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   code-block-writer@13.0.3:
@@ -7795,7 +7796,7 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  cnfast@0.1.0: {}
+  cn@0.2.3: {}
 
   code-block-writer@13.0.3: {}
 


### PR DESCRIPTION
## What

Swaps `cnfast` for [`cn`](https://github.com/shadcn-ui/cn), shadcn's own class-merging engine — the package the shadcn registry now standardises on. Conflict-resolution semantics match `tailwind-merge` v3.

Run with `npx shadcn@latest migrate cn`, once in `packages/ui` and once in `content/expanding-header-menu` (from the workspace root it fails on `ERR_PNPM_ADDING_TO_ROOT`).

## Changes

- `packages/ui/src/lib/utils.ts`: `export { cn } from "cnfast"` → `export { cn } from "cn"`
- `content/expanding-header-menu/`: the one content component that imports `cn` directly — its import and its `package.json` dependency, so the registry item served at `/r/expanding-header-menu.json` tells consumers to install `cn`
- lockfile updated; pnpm also corrected a stale `@types/react-dom` pin in one importer (19.2.4 → 19.2.5, the version the catalog already resolves everywhere else)

## Verification

`pnpm typecheck` and `pnpm format` pass. `pnpm lint` reports only the pre-existing advisory warnings (`content/expanding-header-menu`'s two `next/no-img-element` hits are on `main` too). `pnpm test` fails identically on `main` — the `src/**/*.test.ts` globs match no files — so it is pre-existing.

`pnpm build` was not run here: it needs a populated `.env`, which a fresh clone has no way to fill. Vercel's build on this branch is the gate for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fuAGAmG66YvgRKtrkidAV

---
_Generated by [Claude Code](https://claude.ai/code/session_011fuAGAmG66YvgRKtrkidAV)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Swaps `cnfast` for `cn`, the class-merging engine shadcn's registry now standardizes on, in `packages/ui` and `content/expanding-header-menu`. Conflict-resolution semantics are unchanged (matching `tailwind-merge` v3).

**Migration**
- Run `npx shadcn@latest migrate cn` in `packages/ui` and in `content/expanding-header-menu`; running it from the workspace root fails with `ERR_PNPM_ADDING_TO_ROOT`.
- The registry item for `expanding-header-menu` now declares `cn` as a dependency so consumers install it.
- The lockfile also corrects a stale `@types/react-dom` pin (19.2.4 → 19.2.5) in one importer.

<sup>Written for commit 13c3aa2261f40dc2fedf34483ffd1b175748eb1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

