### PR TITLE
Record covers at 60fps; cover the 12 uncovered components

### DIFF
--- a/.claude/skills/build-content/SKILL.md
+++ b/.claude/skills/build-content/SKILL.md
@@ -88,15 +88,14 @@ Screenshot `/preview-frame/<slug>` and actually look at it before recording.
 
 ## 4. Record
 
-The staging recipe and its two gotchas (`record start` opens a NEW tab; capture size
-locks when recording begins) plus the occlusion check live in
+The staging recipe (viewport locks at `record start`; occlusion check) lives in
 `../cover-video/SKILL.md` §2–3 — follow that recipe, with these differences:
 
 - Viewport **1280×800** (PR gif, not gallery cover) — so the eval check must print
   `visible 1280x800`, not the `1600x900` the cover-video recipe shows.
-- Record `http://localhost:3000/preview-frame/<slug>`.
-- `record restart <file>` prints "Recording saved to <file>" immediately, before
-  anything is captured — it's re-arming, not saving. Ignore that line.
+- Open and stage `http://localhost:3000/preview-frame/<slug>`, then
+  `record start <scratch>/<slug>.webm --fps 60`. Always `--fps 60` — the GIF downsamples,
+  but a 30fps source aliases drags and springs before the GIF ever sees them.
 - 10–15s choreography as ONE `agent-browser batch` call: ~3s settle, then the beats
   you designed in step 2 (drags need intermediate `mouse move` steps with 80–120ms
   waits), then ~3s settle so the loop reads cleanly.

--- a/.claude/skills/build-content/SKILL.md
+++ b/.claude/skills/build-content/SKILL.md
@@ -14,7 +14,7 @@ description: >
 # Build Content
 
 Idea → branch → scaffold → build → verify → record → PR with embedded recording.
-Use the session scratchpad for all intermediate files (webm, gif, frames, batch json).
+Use the session scratchpad for all intermediate files (raw mp4, gif, frames, batch json).
 
 ## 0. No idea given? Pitch, then ask
 
@@ -94,14 +94,15 @@ The staging recipe (viewport locks at `record start`; occlusion check) lives in
 - Viewport **1280×800** (PR gif, not gallery cover) — so the eval check must print
   `visible 1280x800`, not the `1600x900` the cover-video recipe shows.
 - Open and stage `http://localhost:3000/preview-frame/<slug>`, then
-  `record start <scratch>/<slug>.webm --fps 60`. Always `--fps 60` — the GIF downsamples,
-  but a 30fps source aliases drags and springs before the GIF ever sees them.
+  `record start <scratch>/<slug>.raw.mp4 --fps 60`. Always `--fps 60` — the GIF
+  downsamples, but a 30fps source aliases drags and springs before the GIF ever sees
+  them. Always `.mp4` — see the cover-video skill for why webm takes die early.
 - 10–15s choreography as ONE `agent-browser batch` call: ~3s settle, then the beats
   you designed in step 2 (drags need intermediate `mouse move` steps with 80–120ms
   waits), then ~3s settle so the loop reads cleanly.
 - The OS cursor is not captured — favor beats with visible feedback.
 
-After `record stop`, verify the webm: non-zero size AND duration ≥ 8s
+After `record stop`, verify the file: non-zero size AND duration ≥ 8s
 (`ffprobe -v error -show_entries format=duration -of csv=p=0 <file>`). A 0-byte or
 sub-second file is a known intermittent agent-browser failure — re-record, waiting
 2s after `record stop` before checking.
@@ -109,7 +110,7 @@ sub-second file is a known intermittent agent-browser failure — re-record, wai
 ## 5. Convert, frame-check, publish the GIF
 
 ```bash
-.claude/skills/build-content/scripts/publish-recording.sh <slug> <scratch>/<slug>.webm
+.claude/skills/build-content/scripts/publish-recording.sh <slug> <scratch>/<slug>.raw.mp4
 ```
 
 Converts to an 800px 12fps GIF, uploads it to the `kyh/pr-preview-assets` orphan
@@ -157,7 +158,7 @@ finishes; the gif renders immediately.)
 
 ## 7. Wrap up
 
-- Delete scratch webm/gif/frames/batch files.
+- Delete scratch mp4/gif/frames/batch files.
 - Report the PR URL and your take on the component.
 - Offer, don't do: gallery cover via the `cover-video` skill (separate 1600×900 mp4
   pipeline + Supabase), typically after the PR merges.

--- a/.claude/skills/build-content/scripts/publish-recording.sh
+++ b/.claude/skills/build-content/scripts/publish-recording.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
-# publish-recording.sh <slug> <webm-path>
-# webm -> 800px/12fps GIF -> kyh/pr-preview-assets orphan branch -> print raw embed URL
+# publish-recording.sh <slug> <recording-path>
+# recording (mp4/webm) -> 800px/12fps GIF -> kyh/pr-preview-assets orphan branch -> print raw embed URL
 set -euo pipefail
 
-SLUG="${1:?usage: publish-recording.sh <slug> <webm-path>}"
-WEBM="${2:?usage: publish-recording.sh <slug> <webm-path>}"
+SLUG="${1:?usage: publish-recording.sh <slug> <recording-path>}"
+SRC="${2:?usage: publish-recording.sh <slug> <recording-path>}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 ASSETS_BRANCH="kyh/pr-preview-assets"
-GIF="$(dirname "$WEBM")/$SLUG.gif"
+GIF="$(dirname "$SRC")/$SLUG.gif"
 WT="$(mktemp -d)/assets"
 
-[ -s "$WEBM" ] || { echo "ERROR: $WEBM is missing or empty" >&2; exit 1; }
-DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$WEBM")
+[ -s "$SRC" ] || { echo "ERROR: $SRC is missing or empty" >&2; exit 1; }
+DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$SRC")
 python3 -c "exit(0 if float('$DUR') >= 8 else 1)" || {
   echo "ERROR: recording is only ${DUR}s (<8s) — re-record" >&2; exit 1; }
 
-ffmpeg -y -v error -i "$WEBM" \
+ffmpeg -y -v error -i "$SRC" \
   -vf "fps=12,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
   "$GIF"
 echo "gif: $GIF ($(stat -f%z "$GIF") bytes, ${DUR}s source)"

--- a/.claude/skills/cover-video/SKILL.md
+++ b/.claude/skills/cover-video/SKILL.md
@@ -7,6 +7,8 @@ description: Record a cover video for a content component, verify it looks right
 
 Produce the looping cover video shown on the gallery card for a `content/<slug>` component.
 Pipeline: stage → record → convert → frame-check → upload → update meta.json → confirm live.
+A component with no motion at all (static markup) gets a 1600×900 screenshot as
+`coverType: "image"` instead — a video of nothing moving is dead weight on the card.
 
 Target spec (matches existing covers + the `aspect-video` gallery card):
 
@@ -15,7 +17,7 @@ Target spec (matches existing covers + the `aspect-video` gallery card):
 - Shows the component's most flattering interaction loop, ending near the starting state so
   the loop reads cleanly
 
-Use the session scratchpad for all intermediate files (webm, mp4, frames, batch json).
+Use the session scratchpad for all intermediate files (raw mp4, mp4, frames, batch json).
 
 ## 1. Preflight
 
@@ -34,40 +36,51 @@ Requires agent-browser ≥ 0.37 (`agent-browser --version`; upgrade with
 `npm i -g agent-browser@latest`) and ffmpeg on PATH (`agent-browser doctor`). Recording
 captures the tab you already have open — no new tab, no navigation — so stage everything
 first, then arm capture. **Capture size locks when recording begins**, so the viewport must
-already be 1600×900 before `record start`.
+already be 1600×900 before `record start`. Use a dedicated `--session` (e.g. `covers`) so a
+parallel agent-browser user can't swap the active tab under you.
 
 ```bash
-agent-browser close                                          # fresh session, window foregrounded
-agent-browser open http://localhost:3000/preview-frame/<slug>
-agent-browser set viewport 1600 900
+agent-browser --session covers close                         # fresh session, window foregrounded
+agent-browser --session covers open http://localhost:3000/preview-frame/<slug>
+agent-browser --session covers set viewport 1600 900
 sleep 3
-agent-browser eval "document.querySelector('nextjs-portal')?.remove(); document.querySelectorAll('[data-nextjs-toast],[data-next-badge-root]').forEach(e => e.remove()); document.visibilityState + ' ' + window.innerWidth + 'x' + window.innerHeight"
+agent-browser --session covers eval "document.visibilityState + ' ' + window.innerWidth + 'x' + window.innerHeight"
 # MUST print "visible 1600x900". "hidden" → the window is occluded; rAF freezes and the video
 # will record frozen animation even though screenshots look fine. Close and reopen.
-agent-browser screenshot <scratch>/stage.png                 # Read it: layout ok, no dev badge,
-                                                             # measure your click coordinates HERE
+agent-browser --session covers screenshot <scratch>/stage.png   # Read it: layout ok,
+                                                                # measure click coordinates HERE
 ```
 
 Coordinates measured on `stage.png` are the coordinates the recording sees — same tab, same
-viewport.
+viewport. `next.config.js` sets `devIndicators: false`, so there is no dev badge to strip.
 
-## 3. Record: `--fps 60`, ONE batch call
+If the component is small in a 1600×900 frame (a pill, a toggle), scale the preview's inner
+block before measuring — `transform: scale(1.8)` on `main`'s first child, origin center —
+then measure buttons with `getBoundingClientRect()`. Never `zoom` the root: it rescales
+`h-dvh` and pushes the layout off-screen.
+
+## 3. Record: native mp4, `--fps 60`, ONE batch call
 
 ```bash
-agent-browser eval "document.visibilityState"                # final occlusion check
-agent-browser record start <scratch>/<slug>.webm --fps 60
-agent-browser batch < <scratch>/batch.json
-agent-browser record stop
+agent-browser --session covers eval "document.visibilityState"   # final occlusion check
+agent-browser --session covers record start <scratch>/<slug>.raw.mp4 --fps 60
+agent-browser --session covers batch < <scratch>/batch.json
+agent-browser --session covers record stop
 sleep 2
-ffprobe -v error -show_entries stream=avg_frame_rate,width,height:format=duration -of default=nw=1 <scratch>/<slug>.webm
+ffprobe -v error -show_entries stream=avg_frame_rate,width,height:format=duration -of default=nw=1 <scratch>/<slug>.raw.mp4
 # expect 60/1, 1600, 900, duration ≥ 8
 ```
 
 - **Always pass `--fps 60`.** The default is 30, which visibly stutters springs, drags and
   particle motion on the gallery card. 60 is the ceiling.
-- Record `.webm`, not `.mp4`: agent-browser's native mp4 comes out full-range `yuvj420p`
-  with `moov` after `mdat` (no faststart), which breaks the cover spec. Convert in step 4.
-- A 0-byte or sub-second webm is a known intermittent failure — re-record.
+- **Record `.mp4`, not `.webm`.** agent-browser encodes webm with libvpx, which cannot
+  sustain 60fps on photo-heavy pages; when it falls behind the take silently ends early
+  (a 3–9s file, "No recording in progress" on stop) with no error. x264 keeps up. The
+  native mp4 is ~20 Mbps full-range `yuvj420p` without faststart — step 4 normalizes it.
+- **Entrance is the beat?** Pass the URL to `record start` so capture begins before the
+  navigation: `record start <file> http://localhost:3000/preview-frame/<slug> --fps 60`.
+  Stage on the same URL first anyway, so the viewport is already locked.
+- A sub-second file is a known intermittent failure — re-record.
 
 Individual CLI calls cost ~0.4s each — a 20-action take balloons from 12s to 27s. Write the
 whole choreography as a batch file instead (timing lives in `wait` entries):
@@ -79,12 +92,23 @@ whole choreography as a batch file instead (timing lives in `wait` entries):
  ["mouse","move","740","545"],["wait","90"], ...smooth drag steps...
  ["mouse","up"],["wait","800"],
  ["mouse","move","828","584"],["mouse","down"],["mouse","up"],["wait","120"],  # a click
+ ["mouse","wheel","-250"],                                                     # zoom/scroll
+ ["press","Escape"],
+ ["eval","document.querySelector(\"button[aria-label='Close']\")?.click()"],  # see below
  ["keyboard","type","hello"], ...]
 ```
 
 - Coordinate clicks are move/down/up triads — `click` only takes selectors/@refs.
+- **Don't `click <selector>` on an element that never stops moving** (a drifting wall, a
+  card in a perpetual animation): actionability waits stall for ~10s and wreck the timing.
+  Dispatch it from `eval` with `.click()` instead — instant, and React `onClick` fires.
+- A batch step that errors aborts the rest of the batch; the recording keeps running until
+  `record stop`. Check the batch output, not just the file.
 - Drags need several intermediate `mouse move` steps with 80–120ms waits or they read as
   teleports. At 60fps every step is visible, so use more, smaller steps rather than fewer.
+- macOS-style docks magnify under a horizontal sweep and shift their icons: approach the
+  target vertically after the dock relaxes, or the click lands on a neighbour.
+- `press Escape` only reaches an element that has focus; prefer a visible close control.
 - The OS cursor is not captured — favor components whose feedback is visible (touch
   indicators, hover states, motion). Verify state-dependent coordinates (buttons that only
   exist mid-flow) from an earlier interactive session on `/ui/<slug>`.
@@ -92,11 +116,13 @@ whole choreography as a batch file instead (timing lives in `wait` entries):
 ## 4. Convert
 
 ```bash
-ffmpeg -y -i <slug>.webm -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p -an -movflags +faststart <slug>.mp4
+ffmpeg -y -i <slug>.raw.mp4 -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p -color_range tv -an -movflags +faststart <slug>.mp4
 ```
 
 (Recording is already 1600×900 at 60fps — no scale or fps filter needed; the mp4 keeps 60.
-If size is off, you staged wrong; go back to step 2 rather than upscaling.)
+If size is off, you staged wrong; go back to step 2 rather than upscaling.) Photo-dense
+components (a wall of images in constant motion) come out 20MB+ at crf 18; use crf 24
+there — existing covers sit between 1 and 10MB.
 
 ## 5. Frame-check (do not skip, do not upload on failure)
 
@@ -140,4 +166,4 @@ Add to `content/<slug>/meta.json` (keys before `tags`):
 ```
 
 Open `http://localhost:3000/`, screenshot, and confirm the component's card is playing the
-video (a blank card = bad URL or content-type). Delete scratch webm/mp4/frames/batch files.
+video (a blank card = bad URL or content-type). Delete scratch mp4/frames/batch files.

--- a/.claude/skills/cover-video/SKILL.md
+++ b/.claude/skills/cover-video/SKILL.md
@@ -10,7 +10,7 @@ Pipeline: stage → record → convert → frame-check → upload → update met
 
 Target spec (matches existing covers + the `aspect-video` gallery card):
 
-- 16:9, 1600×900
+- 16:9, 1600×900, 60fps
 - 8–15 seconds, h264 mp4, yuv420p, no audio, `-movflags +faststart`
 - Shows the component's most flattering interaction loop, ending near the starting state so
   the loop reads cleanly
@@ -28,17 +28,18 @@ curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/preview-frame/<slug
 - Read the component source and script a choreography: 3–5 beats covering the component's
   states, ~10–13s total, ending near idle.
 
-## 2. Stage the recording tab (two agent-browser gotchas live here)
+## 2. Stage the recording tab
 
-**Gotcha A — `record start` opens a NEW tab** at the default viewport (1280×634). Anything you
-set on the current tab (viewport, overlay removal) does NOT apply, and coordinates measured
-there will miss. **Gotcha B — capture size locks when recording begins**, so the tab must
-already be 1600×900 when the real recording starts. The recipe that handles both:
+Requires agent-browser ≥ 0.37 (`agent-browser --version`; upgrade with
+`npm i -g agent-browser@latest`) and ffmpeg on PATH (`agent-browser doctor`). Recording
+captures the tab you already have open — no new tab, no navigation — so stage everything
+first, then arm capture. **Capture size locks when recording begins**, so the viewport must
+already be 1600×900 before `record start`.
 
 ```bash
 agent-browser close                                          # fresh session, window foregrounded
-agent-browser record start <scratch>/setup.webm http://localhost:3000/preview-frame/<slug>
-agent-browser set viewport 1600 900                          # applies to the recording tab
+agent-browser open http://localhost:3000/preview-frame/<slug>
+agent-browser set viewport 1600 900
 sleep 3
 agent-browser eval "document.querySelector('nextjs-portal')?.remove(); document.querySelectorAll('[data-nextjs-toast],[data-next-badge-root]').forEach(e => e.remove()); document.visibilityState + ' ' + window.innerWidth + 'x' + window.innerHeight"
 # MUST print "visible 1600x900". "hidden" → the window is occluded; rAF freezes and the video
@@ -47,14 +48,26 @@ agent-browser screenshot <scratch>/stage.png                 # Read it: layout o
                                                              # measure your click coordinates HERE
 ```
 
-`setup.webm` is a throwaway. When the stage looks right:
+Coordinates measured on `stage.png` are the coordinates the recording sees — same tab, same
+viewport.
+
+## 3. Record: `--fps 60`, ONE batch call
 
 ```bash
-agent-browser record restart <scratch>/<slug>.webm           # re-arms capture on the SAME tab,
-                                                             # now at 1600×900 — discards setup footage
+agent-browser eval "document.visibilityState"                # final occlusion check
+agent-browser record start <scratch>/<slug>.webm --fps 60
+agent-browser batch < <scratch>/batch.json
+agent-browser record stop
+sleep 2
+ffprobe -v error -show_entries stream=avg_frame_rate,width,height:format=duration -of default=nw=1 <scratch>/<slug>.webm
+# expect 60/1, 1600, 900, duration ≥ 8
 ```
 
-## 3. Drive the choreography with ONE batch call
+- **Always pass `--fps 60`.** The default is 30, which visibly stutters springs, drags and
+  particle motion on the gallery card. 60 is the ceiling.
+- Record `.webm`, not `.mp4`: agent-browser's native mp4 comes out full-range `yuvj420p`
+  with `moov` after `mdat` (no faststart), which breaks the cover spec. Convert in step 4.
+- A 0-byte or sub-second webm is a known intermittent failure — re-record.
 
 Individual CLI calls cost ~0.4s each — a 20-action take balloons from 12s to 27s. Write the
 whole choreography as a batch file instead (timing lives in `wait` entries):
@@ -69,15 +82,9 @@ whole choreography as a batch file instead (timing lives in `wait` entries):
  ["keyboard","type","hello"], ...]
 ```
 
-```bash
-agent-browser eval "document.visibilityState"    # final occlusion check
-agent-browser batch < <scratch>/batch.json
-agent-browser record stop
-```
-
 - Coordinate clicks are move/down/up triads — `click` only takes selectors/@refs.
 - Drags need several intermediate `mouse move` steps with 80–120ms waits or they read as
-  teleports.
+  teleports. At 60fps every step is visible, so use more, smaller steps rather than fewer.
 - The OS cursor is not captured — favor components whose feedback is visible (touch
   indicators, hover states, motion). Verify state-dependent coordinates (buttons that only
   exist mid-flow) from an earlier interactive session on `/ui/<slug>`.
@@ -88,14 +95,14 @@ agent-browser record stop
 ffmpeg -y -i <slug>.webm -c:v libx264 -crf 18 -preset slow -pix_fmt yuv420p -an -movflags +faststart <slug>.mp4
 ```
 
-(Recording is already 1600×900 — no scale filter needed. If size is off, you staged wrong; go
-back to step 2 rather than upscaling.)
+(Recording is already 1600×900 at 60fps — no scale or fps filter needed; the mp4 keeps 60.
+If size is off, you staged wrong; go back to step 2 rather than upscaling.)
 
 ## 5. Frame-check (do not skip, do not upload on failure)
 
 ```bash
 DUR=$(ffprobe -v quiet -show_entries format=duration -of csv=p=0 <slug>.mp4)
-ffprobe -v quiet -show_entries stream=width,height,codec_name -of csv=p=0 <slug>.mp4
+ffprobe -v quiet -show_entries stream=width,height,codec_name,avg_frame_rate -of csv=p=0 <slug>.mp4
 for p in 8 30 55 80 92; do
   ffmpeg -y -v error -ss $(python3 -c "print($DUR*$p/100)") -i <slug>.mp4 -frames:v 1 frame_$p.png
 done
@@ -107,7 +114,7 @@ Read every frame as an image and check ALL of:
 2. Frames DIFFER and match the planned beats. All-identical frames = interactions missed
    (wrong tab/coords) or rAF frozen (occlusion). Fix the cause, rerecord.
 3. No dev overlays (Next.js badge bottom-left), no error toasts.
-4. Duration 8–15s, 1600×900, h264.
+4. Duration 8–15s, 1600×900, h264, 60fps.
 
 ## 6. Upload
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ package manifests, and imports. Private workspace imports and paths escaping the
 fail the build. Do not remove this guard.
 
 Runtime — drive the real UI with [agent-browser](https://github.com/vercel-labs/agent-browser)
-(installed globally: `npm i -g agent-browser && agent-browser install`):
+(installed globally: `npm i -g agent-browser && agent-browser install`; ≥ 0.37 for `record --fps 60`):
 
 ```sh
 agent-browser open http://localhost:3000/

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -53,6 +53,8 @@ const transpilePackages = ["@repo/api", "@repo/db", "@repo/ui", ...getContentPac
 const config = {
   /** next dev rewrites AGENTS.md/CLAUDE.md when it detects an agent; we own those files */
   agentRules: false,
+  /** cover/PR recordings capture cold navigations; the badge can't be stripped in time */
+  devIndicators: false,
   cacheComponents: true,
   experimental: {
     // Avoid replaying grid skeletons on back navigation; content changes only on deploy.

--- a/content/chibi-plants/meta.json
+++ b/content/chibi-plants/meta.json
@@ -2,5 +2,7 @@
   "name": "Chibi Plants",
   "description": "Cute chibi potted plants raymarched from signed distance fields — they watch your cursor, blink, and morph between characters",
   "addedAt": "2026-08-27",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/chibi-plants/chibi-plants.mp4",
+  "coverType": "video",
   "tags": ["effects", "silly", "colorful"]
 }

--- a/content/desktop-os/meta.json
+++ b/content/desktop-os/meta.json
@@ -2,6 +2,8 @@
   "name": "Desktop OS",
   "description": "A desktop boots itself — one card riffles through every thumbnail, icons burst out from centre, then the dock magnifies under the cursor and windows drag, stack and pop.",
   "addedAt": "2026-07-18",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/desktop-os/desktop-os.mp4",
+  "coverType": "video",
   "tags": ["skeuomorphism", "effects", "productivity"],
   "defaultSize": "full"
 }

--- a/content/dynamic-island/meta.json
+++ b/content/dynamic-island/meta.json
@@ -2,6 +2,8 @@
   "name": "Dynamic Island",
   "description": "A springy Dynamic Island interaction with ring and timer states.",
   "addedAt": "2026-05-02",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/dynamic-island/dynamic-island.mp4",
+  "coverType": "video",
   "tags": ["mobile", "skeuomorphism", "navigation"],
   "inspiredBy": [
     {

--- a/content/editorial-charts/meta.json
+++ b/content/editorial-charts/meta.json
@@ -2,6 +2,8 @@
   "name": "Editorial Charts",
   "description": "A four-card editorial chart set — rung bars, a hairline dot-line, a tick-ring dial, and a dot waffle — drawn ink-on-paper by TanStack Charts, with spring-staggered entrances and quarterly data that morphs on a loop.",
   "addedAt": "2026-09-01",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/editorial-charts/editorial-charts.mp4",
+  "coverType": "video",
   "tags": ["charts", "minimal", "business"],
   "defaultSize": "full"
 }

--- a/content/feed/meta.json
+++ b/content/feed/meta.json
@@ -1,5 +1,7 @@
 {
   "name": "Feed",
   "addedAt": "2025-05-03",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/feed/feed.png",
+  "coverType": "image",
   "tags": ["education", "minimal", "cards"]
 }

--- a/content/formation/meta.json
+++ b/content/formation/meta.json
@@ -2,6 +2,8 @@
   "name": "Formation",
   "description": "Sixteen photo cards regroup between four spatial formations — a solved ellipse, an arc conveyor, a tilted ring and a swelling orbit — while a refracting glass lens tracks the cursor and clicking a card blinks it open behind closing eyelids.",
   "addedAt": "2026-07-18",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/formation/formation.mp4",
+  "coverType": "video",
   "tags": ["effects", "cards", "design", "minimal"],
   "defaultSize": "full"
 }

--- a/content/gravity-wall/meta.json
+++ b/content/gravity-wall/meta.json
@@ -2,6 +2,8 @@
   "name": "Gravity Wall",
   "description": "A drifting wall of photos bends away from the cursor like a gravity well, promoting whichever picture sits in the clearing — click and the whole wall pans to bring it to center.",
   "addedAt": "2026-07-18",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/gravity-wall/gravity-wall.mp4",
+  "coverType": "video",
   "tags": ["design", "grids", "carousels"],
   "defaultSize": "full"
 }

--- a/content/liquid-orb/meta.json
+++ b/content/liquid-orb/meta.json
@@ -2,5 +2,7 @@
   "name": "Liquid Orb",
   "description": "Liquid-glass shader orb that morphs through material presets — siri, aurora, plasma, chrome, opal, blue drop, violet ember",
   "addedAt": "2026-09-01",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/liquid-orb/liquid-orb.mp4",
+  "coverType": "video",
   "tags": ["effects", "geometric", "design"]
 }

--- a/content/lookbook-camera/meta.json
+++ b/content/lookbook-camera/meta.json
@@ -2,6 +2,8 @@
   "name": "Lookbook Camera",
   "description": "A camera drifts forever across an edgeless field of fashion figures — scroll to zoom at the cursor, drag to fling, click one and it flies in while every other card dims and a glass panel slides out.",
   "addedAt": "2026-07-18",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/lookbook-camera/lookbook-camera.mp4",
+  "coverType": "video",
   "tags": ["grids", "design", "effects", "cards"],
   "defaultSize": "full"
 }

--- a/content/paper-roll/meta.json
+++ b/content/paper-roll/meta.json
@@ -2,6 +2,8 @@
   "name": "Paper Roll",
   "description": "An endless strip of paper unrolls behind a heavy roll, printing a portfolio in its wake",
   "addedAt": "2026-07-22",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/paper-roll/paper-roll.mp4",
+  "coverType": "video",
   "tags": ["effects", "skeuomorphism", "design"],
   "inspiredBy": [
     {

--- a/content/stat-reel/meta.json
+++ b/content/stat-reel/meta.json
@@ -2,6 +2,8 @@
   "name": "Stat Reel",
   "description": "An endless wheel of labels glides past a fixed center line while a giant gradient-filled figure swaps in beside it; scroll to seize the reel and it resumes on its own after four seconds.",
   "addedAt": "2026-07-18",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/stat-reel/stat-reel.mp4",
+  "coverType": "video",
   "tags": ["business", "charts", "minimal"],
   "defaultSize": "full"
 }

--- a/content/terminal-disintegrate/meta.json
+++ b/content/terminal-disintegrate/meta.json
@@ -3,5 +3,7 @@
   "description": "An ASCII trading terminal drawn from box-drawing glyphs, whose screen burns into drifting embers and reassembles as the next one — scrub backwards and the same debris replays in reverse.",
   "addedAt": "2026-07-18",
   "defaultSize": "full",
+  "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/terminal-disintegrate/terminal-disintegrate.mp4",
+  "coverType": "video",
   "tags": ["finance", "pixel-art", "effects"]
 }


### PR DESCRIPTION
agent-browser 0.37 records the active tab at up to 60fps via \`Page.startScreencast\`, so the cover-video and build-content skills now stage first, then \`record start … --fps 60\` on the same tab (no more new-tab / \`record restart\` dance). Two findings baked into the skill: webm takes silently end after 3–9s on photo-dense pages because libvpx can't keep up at 60fps, so recordings are native mp4 normalized by ffmpeg; and \`click <selector>\` on a perpetually-moving element stalls on actionability, so those clicks dispatch from \`eval\`. \`devIndicators: false\` in dev so cold-navigation takes (entrance beats) carry no badge.

New 1600×900 60fps covers uploaded to Supabase and wired into \`meta.json\` for: chibi-plants, desktop-os, dynamic-island (staged at 1.8× so the island is legible on the card), editorial-charts, formation, gravity-wall (crf 24, 7.7MB), liquid-orb, lookbook-camera, paper-roll, stat-reel, terminal-disintegrate. **feed** is static markup with zero motion, so it gets a still as \`coverType: "image"\` rather than a video of nothing.

Verified: every mp4 frame-checked at 8/30/55/80/92% for beat coverage; gallery home shows the new cards playing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Y7x4u8gAcgggZJw19QEYY

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the cover-video and build-content skills to record covers at 60fps using agent-browser 0.37's native screencast, and adds gallery covers for 12 components that previously had none.

**Recording pipeline**
- Records natively as mp4 at 60fps; webm silently ends early on photo-dense pages.
- Stages the component first, then `record start --fps 60` on the same tab — no new tab or restart.
- Dispatches clicks on perpetually-moving elements via `eval` to avoid actionability stalls.
- Disables `devIndicators` so cold-navigation captures show no badge.

**New covers**
- Adds 1600×900 60fps mp4 covers, frame-checked at 5 points, for the 12 components.
- Gives `feed` a still image cover since it has zero motion.

<sup>Written for commit fa09b7e10e1f00b4f781c0ce44e8be24aaca9522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

