### PR TITLE
formation: drop glass lens + detail overlay, keep carousel; re-record cover

### DIFF
--- a/.claude/skills/cover-video/SKILL.md
+++ b/.claude/skills/cover-video/SKILL.md
@@ -153,8 +153,11 @@ curl -s -o /dev/null -w "%{http_code} %{content_type}" \
 # expect: 200 video/mp4
 ```
 
-Storage sits behind a CDN (~1h cache) — replacing an existing cover can serve stale for a
-while; mention that when overwriting.
+`cp` never overwrites — an existing object fails with `409 KeyAlreadyExists`. Replacing a
+cover means `supabase storage rm ss:///uicapsule/<slug>/<slug>.mp4 --experimental --yes`
+first (without `--yes` the confirm prompt ignores piped stdin and silently does nothing).
+Storage sits behind a CDN (~1h cache) — a replaced cover can serve stale for a while;
+mention that when overwriting.
 
 ## 7. Wire up + confirm
 

--- a/content/formation/formation-poses.ts
+++ b/content/formation/formation-poses.ts
@@ -5,9 +5,6 @@ export type FormationMode = "flat" | "tilt" | "ring" | "gallery";
 
 export interface Work {
   title: string;
-  category: string;
-  /** Accent used for the rule under the detail title. */
-  accent: string;
   image: string;
 }
 
@@ -265,16 +262,3 @@ export const poseFor = (mode: FormationMode, i: number, L: FmLayout, browse: num
   if (mode === "ring") return ringPose(i, L, browse);
   return galleryPose(i, L, browse);
 };
-
-// The liquid-glass normal map — a glass bead: clear in the centre, bending at the rim.
-export const GLASS_NORMAL_MAP =
-  "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><defs>" +
-  "<linearGradient id='r' x1='0' y1='0' x2='1' y2='0'><stop offset='0' stop-color='rgb(0,0,0)'/>" +
-  "<stop offset='1' stop-color='rgb(255,0,0)'/></linearGradient>" +
-  "<linearGradient id='g' x1='0' y1='0' x2='0' y2='1'><stop offset='0' stop-color='rgb(0,0,0)'/>" +
-  "<stop offset='1' stop-color='rgb(0,255,0)'/></linearGradient>" +
-  "<radialGradient id='n'><stop offset='0.32' stop-color='rgb(128,128,128)' stop-opacity='1'/>" +
-  "<stop offset='1' stop-color='rgb(128,128,128)' stop-opacity='0'/></radialGradient></defs>" +
-  "<rect width='100' height='100' fill='url(%23r)'/>" +
-  "<rect width='100' height='100' fill='url(%23g)' style='mix-blend-mode:screen'/>" +
-  "<rect width='100' height='100' fill='url(%23n)'/></svg>";

--- a/content/formation/formation.tsx
+++ b/content/formation/formation.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import type { CSSProperties, PointerEvent as ReactPointerEvent, ReactNode } from "react";
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import gsap from "gsap";
-import { X } from "lucide-react";
 
 import type { FmLayout, FormationMode, Pose, Work } from "./formation-poses";
 import {
@@ -12,7 +11,6 @@ import {
   easeInOut,
   focusScore,
   getLayout,
-  GLASS_NORMAL_MAP,
   HOVER_EASE,
   HOVER_ZOOM,
   lerpPose,
@@ -35,14 +33,6 @@ import {
 const SANS =
   'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif';
 const MONO = 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace';
-
-// Narrowest *root* width that gets the custom lens cursor. The lens is also a
-// fine-pointer affordance only — on touch it would freeze at its last known
-// position. Both conditions live in JS (`LoopState.lens`, which also drives the
-// element's `display`) rather than a CSS media query, because a query would test
-// the viewport while every other measurement here is root-relative: embedded
-// narrower than the window, the two disagree.
-const LENS_MIN_W = 640;
 
 interface CustomCSS extends CSSProperties {
   [key: `--${string}`]: string | number | undefined;
@@ -71,9 +61,6 @@ interface LoopState {
   onScreen: boolean;
   visible: boolean;
   reduced: boolean;
-  pointerFine: boolean;
-  /** Is the lens cursor currently rendered? Recomputed on layout, not per frame. */
-  lens: boolean;
   browse: number;
   vel: number;
   morphing: boolean;
@@ -85,7 +72,6 @@ interface LoopState {
   curTY: number;
   /** Pointer position, root-relative. */
   cursor: { x: number; y: number; inside: boolean };
-  glass: { x: number; y: number; scale: number; opacity: number };
   /**
    * The pointer currently being tracked, if any. `committed` means it has moved
    * past the tap slop and is now scrubbing — i.e. it *is* the drag state, so
@@ -94,7 +80,6 @@ interface LoopState {
   press: { x: number; y: number; id: number; committed: boolean } | null;
   /** Previous pointer x, root-relative — the scrub delta is measured against it. */
   lastX: number;
-  overUI: boolean;
 }
 
 const zeroPose = (): Pose => ({
@@ -114,8 +99,6 @@ const createState = (): LoopState => ({
   onScreen: true,
   visible: true,
   reduced: false,
-  pointerFine: false,
-  lens: false,
   browse: 0,
   vel: 0,
   morphing: false,
@@ -126,10 +109,8 @@ const createState = (): LoopState => ({
   curTX: 0,
   curTY: 0,
   cursor: { x: 0, y: 0, inside: false },
-  glass: { x: -100, y: -100, scale: 1, opacity: 0 },
   press: null,
   lastX: 0,
-  overUI: false,
 });
 
 const makeCards = (works: Work[]): CardState[] =>
@@ -159,27 +140,10 @@ interface FormationProps {
 
 export const Formation = ({ works }: FormationProps): ReactNode => {
   const [mode, setMode] = useState<FormationMode>("flat");
-  const [detail, setDetail] = useState<{ card: CardState } | null>(null);
-
-  const rawId = useId();
-  const filterId = `fm-liquid-${rawId.replace(/[^a-zA-Z0-9]/g, "")}`;
 
   const rootRef = useRef<HTMLElement | null>(null);
   const parallaxRef = useRef<HTMLDivElement | null>(null);
-  const glassRef = useRef<HTMLDivElement | null>(null);
   const counterRef = useRef<HTMLSpanElement | null>(null);
-
-  // Detail-overlay refs
-  const bdRef = useRef<HTMLDivElement | null>(null);
-  const imgWrapRef = useRef<HTMLDivElement | null>(null);
-  const imgInnerRef = useRef<HTMLDivElement | null>(null);
-  const scrimRef = useRef<HTMLDivElement | null>(null);
-  const detailBoxRef = useRef<HTMLDivElement | null>(null);
-  const titleRef = useRef<HTMLHeadingElement | null>(null);
-  const ruleRef = useRef<HTMLSpanElement | null>(null);
-  const closeBtnRef = useRef<HTMLButtonElement | null>(null);
-  const lidTopRef = useRef<HTMLDivElement | null>(null);
-  const lidBotRef = useRef<HTMLDivElement | null>(null);
 
   // Mutable engine state (never triggers a re-render)
   const sRef = useRef<LoopState | null>(null);
@@ -200,16 +164,8 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
   /** Root's live client box — pointer coords are converted against it. */
   const boxRef = useRef({ left: 0, top: 0, w: 0, h: 0 });
   const modeRef = useRef<FormationMode>("flat");
-  const openRef = useRef(false);
-  const openingRef = useRef(false);
-  const closingRef = useRef(false);
-  const openTlRef = useRef<gsap.core.Timeline | null>(null);
-  const closeTlRef = useRef<gsap.core.Timeline | null>(null);
   const firstMode = useRef(true);
-  const fnRef = useRef<{ closeDetail: () => void; renderStatic: () => void }>({
-    closeDetail: () => {},
-    renderStatic: () => {},
-  });
+  const renderStaticRef = useRef<() => void>(() => {});
 
   // ── Geometry helpers (read refs only — safe to capture once) ─────────────
   const applyCardSizes = () => {
@@ -226,7 +182,7 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
   };
 
   /** Painter's-algorithm hit test in root-relative space; highest z wins. */
-  const rectHit = (px: number, py: number, sticky: boolean) => {
+  const hoverHit = (px: number, py: number) => {
     const box = boxRef.current;
     const inRect = (el: HTMLDivElement) => {
       const r = el.getBoundingClientRect();
@@ -236,7 +192,7 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     };
     const stickyCard = S.hoverCard;
     // Bias toward whatever is already hovered so a hairline overlap can't flicker.
-    if (sticky && stickyCard && stickyCard.cur.o >= 0.5 && stickyCard.outer) {
+    if (stickyCard && stickyCard.cur.o >= 0.5 && stickyCard.outer) {
       if (inRect(stickyCard.outer)) return stickyCard;
     }
     let best: CardState | null = null;
@@ -252,8 +208,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     }
     return best;
   };
-  const hoverHit = (px: number, py: number) => rectHit(px, py, true);
-  const resolveCardAt = (px: number, py: number) => rectHit(px, py, false);
 
   const renderStatic = () => {
     const L = layoutRef.current;
@@ -281,53 +235,10 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     }
   };
 
-  // ── Detail open / close ──────────────────────────────────────────────────
-  const openDetail = (card: CardState) => {
-    if (openingRef.current || closingRef.current || openRef.current) return;
-    S.hoverCard = null;
-    openRef.current = true;
-    openingRef.current = true;
-    setDetail({ card });
-  };
-
-  const closeDetail = () => {
-    if (closingRef.current || !openRef.current) return;
-    // A close can interrupt the (long) open blink rather than waiting it out.
-    if (openingRef.current) {
-      openTlRef.current?.kill();
-      openingRef.current = false;
-    }
-    if (S.reduced) {
-      openRef.current = false;
-      setDetail(null);
-      return;
-    }
-    closingRef.current = true;
-    const lids = [lidTopRef.current, lidBotRef.current];
-    const tl = gsap.timeline({
-      onComplete: () => {
-        closingRef.current = false;
-        setDetail(null);
-      },
-    });
-    closeTlRef.current = tl;
-    tl.to(detailBoxRef.current, { autoAlpha: 0, duration: 0.28, ease: "power2.in" }, 0)
-      .to(lids, { scaleY: 1, duration: 0.6, ease: "power2.inOut" }, 0.05)
-      .add(() => {
-        openRef.current = false;
-        gsap.set([imgWrapRef.current, scrimRef.current, bdRef.current, closeBtnRef.current], {
-          opacity: 0,
-        });
-      }, 0.66)
-      .to(lids, { scaleY: 0, duration: 0.95, ease: "power3.out" }, 0.74);
-  };
-
   // ── Pointer input (React handlers → latest closures) ─────────────────────
   // Every handler is gated on the tracked `pointerId`: on touch, a second
-  // contact landing mid-swipe must not hijack the drag (or, worse, be read as a
-  // tap and open the detail view under the finger that is still scrubbing).
+  // contact landing mid-swipe must not hijack the drag.
   const onPointerDown = (e: ReactPointerEvent<HTMLElement>) => {
-    if (openRef.current) return;
     if (isUI(e.target)) return;
     if (S.press) return;
     const box = boxRef.current;
@@ -349,12 +260,10 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     S.cursor.x = lx;
     S.cursor.y = ly;
     S.cursor.inside = true;
-    S.overUI = isUI(e.target);
-    if (openRef.current) return;
     if (press && !S.morphing) {
       if (!press.committed) {
         const dist = Math.hypot(lx - press.x, ly - press.y);
-        // 8px of slop, so a click still opens the detail view.
+        // 8px of slop so a jittery tap on touch doesn't nudge the carousel.
         if (dist > 8) {
           press.committed = true;
           try {
@@ -374,25 +283,13 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     S.lastX = lx;
   };
 
-  /** `mayTap`: a press that never committed opens the detail view it ended on. */
-  const endPress = (e: ReactPointerEvent<HTMLElement>, mayTap: boolean) => {
+  const endPress = (e: ReactPointerEvent<HTMLElement>) => {
     const press = S.press;
     if (!press || press.id !== e.pointerId) return;
     const root = rootRef.current;
     if (root?.hasPointerCapture(press.id)) root.releasePointerCapture(press.id);
     S.press = null;
-    if (mayTap && !press.committed && !openRef.current) {
-      const card = resolveCardAt(press.x, press.y);
-      if (card) openDetail(card);
-    }
   };
-
-  const onPointerUp = (e: ReactPointerEvent<HTMLElement>) => endPress(e, true);
-
-  // The browser can claim a touch gesture mid-drag (vertical scroll on the
-  // `pan-y` root). Release the same state as pointerup, but never treat the
-  // interrupted press as a tap — that would open the detail view mid-scroll.
-  const onPointerCancel = (e: ReactPointerEvent<HTMLElement>) => endPress(e, false);
 
   const onPointerLeave = () => {
     // An uncommitted press can be released outside the root — no capture has
@@ -405,9 +302,9 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     S.hoverCard = null;
   };
 
-  // Keep listener-bound callbacks fresh.
+  // Keep the mode effect's reduced-motion path on the latest closure.
   useEffect(() => {
-    fnRef.current = { closeDetail, renderStatic };
+    renderStaticRef.current = renderStatic;
   });
 
   // ── Mount: layout, engine loop, lifecycle ────────────────────────────────
@@ -417,7 +314,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     const st = S;
 
     st.reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    st.pointerFine = window.matchMedia("(pointer: fine)").matches;
 
     const box = boxRef.current;
 
@@ -439,11 +335,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     const relayout = () => {
       if (!measure()) return;
       layoutRef.current = getLayout(box.w, box.h, n);
-      st.pointerFine = window.matchMedia("(pointer: fine)").matches;
-      // The lens's visibility and the loop's "may I hide the native cursor?"
-      // test are the same decision, made once here, in the same units.
-      st.lens = !st.reduced && st.pointerFine && box.w >= LENS_MIN_W;
-      if (glassRef.current) glassRef.current.style.display = st.lens ? "block" : "none";
       // Seed (or re-seed) the virtual cursor at centre so the parallax rests
       // neutral. The first measure inside a fresh iframe can be 0x0, so this has
       // to live here rather than after a single relayout() call.
@@ -457,20 +348,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
 
     // Seeds the layout and, under reduced motion, paints the one static frame.
     relayout();
-
-    const updateGlass = () => {
-      const el = glassRef.current;
-      if (!el || !st.lens) return;
-      st.glass.x += (st.cursor.x - st.glass.x) * 0.22;
-      st.glass.y += (st.cursor.y - st.glass.y) * 0.22;
-      const scaleTgt = isDragging(st) ? 0.78 : st.hoverCard ? 1.5 : 1;
-      st.glass.scale += (scaleTgt - st.glass.scale) * 0.18;
-      const opTgt = st.cursor.inside && !st.overUI && !openRef.current ? 1 : 0;
-      const opEase = st.overUI ? 0.3 : 0.18;
-      st.glass.opacity += (opTgt - st.glass.opacity) * opEase;
-      el.style.transform = `translate3d(${st.glass.x - 28}px, ${st.glass.y - 28}px, 0) scale(${st.glass.scale})`;
-      el.style.opacity = String(st.glass.opacity);
-    };
 
     const updateCounter = () => {
       let focused = st.hoverCard;
@@ -512,32 +389,10 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
       box.left = rr.left;
       box.top = rr.top;
 
-      // Hover hit-test (skipped while the detail view owns the screen, so
-      // `hoverCard` stays as `openDetail` left it).
-      if (!openRef.current) {
-        if (dragging || st.morphing) st.hoverCard = null;
-        else if (st.cursor.inside) st.hoverCard = hoverHit(st.cursor.x, st.cursor.y);
-      }
+      if (dragging || st.morphing) st.hoverCard = null;
+      else if (st.cursor.inside) st.hoverCard = hoverHit(st.cursor.x, st.cursor.y);
 
-      updateGlass();
-
-      // Only surrender the native cursor when the lens is actually on screen and
-      // standing in for it — never at narrow widths, never over the open detail.
-      if (openRef.current) root.style.cursor = "auto";
-      else if (st.lens) root.style.cursor = st.overUI ? "auto" : "none";
-      else
-        root.style.cursor = dragging
-          ? "grabbing"
-          : st.hoverCard
-            ? "pointer"
-            : mode2 === "flat"
-              ? "default"
-              : "grab";
-
-      if (openRef.current) {
-        st.raf = requestAnimationFrame(frame);
-        return;
-      }
+      root.style.cursor = dragging ? "grabbing" : "grab";
 
       // Scrub momentum
       if (!dragging && !st.morphing) {
@@ -662,7 +517,7 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
 
     const onWheel = (e: WheelEvent) => {
       if (isUI(e.target)) return;
-      if (openRef.current || st.reduced) return;
+      if (st.reduced) return;
       e.preventDefault();
       if (st.morphing) return;
       const gain = modeRef.current === "flat" || modeRef.current === "ring" ? 0.6 : 0.8;
@@ -673,11 +528,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     };
     root.addEventListener("wheel", onWheel, { passive: false });
 
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && openRef.current) fnRef.current.closeDetail();
-    };
-    window.addEventListener("keydown", onKey);
-
     if (!st.reduced) start();
 
     return () => {
@@ -687,9 +537,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
       document.removeEventListener("visibilitychange", onVis);
       window.removeEventListener("resize", relayout);
       root.removeEventListener("wheel", onWheel);
-      window.removeEventListener("keydown", onKey);
-      closeTlRef.current?.kill();
-      closeTlRef.current = null;
       // Let a StrictMode remount re-seed poses from scratch, and re-arm the
       // "first mode" short-circuit so the remount doesn't morph from a zero pose.
       st.seeded = false;
@@ -746,7 +593,7 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
       return;
     }
     if (S.reduced) {
-      fnRef.current.renderStatic();
+      renderStaticRef.current();
       return;
     }
     for (const card of cards) copyPose(card.from, card.cur);
@@ -759,75 +606,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     // lives in the engine effect's cleanup, which only runs on unmount.
   }, [mode, cards, S]);
 
-  // Detail open timeline (the eyelid blink).
-  useEffect(() => {
-    if (!detail) return;
-    const lids = [lidTopRef.current, lidBotRef.current];
-    const reveals = detailBoxRef.current?.querySelectorAll("[data-fm-reveal]");
-    // The dialog is modal (the stage behind it is `inert`), so focus has to move
-    // into it — otherwise Tab lands on controls hidden behind an opaque overlay.
-    const restoreTo = document.activeElement;
-    closeBtnRef.current?.focus({ preventScroll: true });
-
-    // The <h2> ships hidden below its clip mask via `translateY(120%)`, which
-    // GSAP reads back as a *pixel* `y` and would then add the percentage on top
-    // of. Zeroing `y` here hands the offset over to `yPercent` cleanly — the
-    // 120% has to stay height-relative for the tween to land flush.
-    const setTitle = (yPercent: number) => gsap.set(titleRef.current, { y: 0, yPercent });
-
-    const restoreFocus = () => {
-      if (restoreTo instanceof HTMLElement) restoreTo.focus({ preventScroll: true });
-    };
-
-    if (S.reduced) {
-      gsap.set(lids, { scaleY: 0 });
-      gsap.set([bdRef.current, imgWrapRef.current, scrimRef.current, closeBtnRef.current], {
-        opacity: 1,
-      });
-      gsap.set(imgInnerRef.current, { scale: 1 });
-      gsap.set(ruleRef.current, { scaleX: 1 });
-      setTitle(0);
-      if (reveals) gsap.set(reveals, { y: 0, opacity: 1 });
-      openingRef.current = false;
-      return restoreFocus;
-    }
-
-    const tl = gsap.timeline({
-      onComplete: () => {
-        openingRef.current = false;
-      },
-    });
-    openTlRef.current = tl;
-    gsap.set(lids, { scaleY: 0 });
-    gsap.set(bdRef.current, { opacity: 0 });
-    gsap.set(imgWrapRef.current, { opacity: 0 });
-    gsap.set(imgInnerRef.current, { scale: 1.4 });
-    gsap.set(scrimRef.current, { opacity: 0 });
-    gsap.set(closeBtnRef.current, { opacity: 0 });
-    gsap.set(ruleRef.current, { scaleX: 0 });
-    setTitle(120);
-    gsap.set(detailBoxRef.current, { autoAlpha: 1 });
-    if (reveals) gsap.set(reveals, { y: 26, opacity: 0 });
-
-    tl.to(lids, { scaleY: 1, duration: 0.6, ease: "power2.inOut" }, 0)
-      .add(() => {
-        gsap.set(bdRef.current, { opacity: 1 });
-        gsap.set(imgWrapRef.current, { opacity: 1 });
-      }, 0.62)
-      .to(imgInnerRef.current, { scale: 1, duration: 2.2, ease: "power2.out" }, 0.62)
-      .to(lids, { scaleY: 0, duration: 1.0, ease: "power3.out" }, 0.7)
-      .to(scrimRef.current, { opacity: 1, duration: 0.7 }, 1.1)
-      .to(closeBtnRef.current, { opacity: 1, duration: 0.5 }, 1.45)
-      .to(ruleRef.current, { scaleX: 1, duration: 0.6 }, 1.45)
-      .to(titleRef.current, { yPercent: 0, duration: 0.95, ease: "power4.out" }, 1.5)
-      .to(reveals ?? [], { y: 0, opacity: 1, duration: 0.7, stagger: 0.1 }, 1.62);
-
-    return () => {
-      tl.kill();
-      restoreFocus();
-    };
-  }, [detail, S]);
-
   const stageStyle: CustomCSS = {
     touchAction: "pan-y",
     fontFamily: SANS,
@@ -837,10 +615,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
     color: "rgba(255,255,255,0.92)",
   };
 
-  const open = detail !== null;
-  const work = detail?.card.work ?? null;
-  const detailNo = detail ? `${pad(detail.card.index + 1)} — ${pad(n)}` : "";
-
   return (
     <section
       ref={rootRef}
@@ -848,84 +622,12 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
       style={stageStyle}
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerCancel}
+      onPointerUp={endPress}
+      onPointerCancel={endPress}
       onPointerLeave={onPointerLeave}
     >
-      {/* Liquid-glass filter: three displacement passes at 33/31/29 recombined
-          per channel, which is where the chromatic fringing comes from. */}
-      <svg width={0} height={0} aria-hidden className="absolute">
-        <filter
-          id={filterId}
-          x="-50%"
-          y="-50%"
-          width="200%"
-          height="200%"
-          colorInterpolationFilters="sRGB"
-        >
-          <feImage
-            href={GLASS_NORMAL_MAP}
-            x="0"
-            y="0"
-            width="56"
-            height="56"
-            preserveAspectRatio="none"
-            result="map"
-          />
-          <feGaussianBlur in="SourceGraphic" stdDeviation="0.9" result="src" />
-          <feDisplacementMap
-            in="src"
-            in2="map"
-            scale="33"
-            xChannelSelector="R"
-            yChannelSelector="G"
-            result="d1"
-          />
-          <feDisplacementMap
-            in="src"
-            in2="map"
-            scale="31"
-            xChannelSelector="R"
-            yChannelSelector="G"
-            result="d2"
-          />
-          <feDisplacementMap
-            in="src"
-            in2="map"
-            scale="29"
-            xChannelSelector="R"
-            yChannelSelector="G"
-            result="d3"
-          />
-          <feColorMatrix
-            in="d1"
-            type="matrix"
-            values="1 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 1 0"
-            result="cr"
-          />
-          <feColorMatrix
-            in="d2"
-            type="matrix"
-            values="0 0 0 0 0  0 1 0 0 0  0 0 0 0 0  0 0 0 1 0"
-            result="cg"
-          />
-          <feColorMatrix
-            in="d3"
-            type="matrix"
-            values="0 0 0 0 0  0 0 0 0 0  0 0 1 0 0  0 0 0 1 0"
-            result="cb"
-          />
-          <feBlend in="cr" in2="cg" mode="screen" result="crg" />
-          <feBlend in="crg" in2="cb" mode="screen" result="crgb" />
-          <feGaussianBlur in="crgb" stdDeviation="0.5" />
-        </filter>
-      </svg>
-
-      {/* The 3D stage. `inert` while the detail is open so Tab can't reach a
-          card sitting behind an opaque overlay. */}
       <div
         className="absolute inset-0"
-        inert={open}
         style={{ perspective: `${PERSP}px`, perspectiveOrigin: "50% 50%" }}
       >
         <div
@@ -939,18 +641,8 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
               ref={(el) => {
                 card.outer = el;
               }}
-              // Not a <button>: this element's transform is rewritten every
-              // frame and it must stay free of UA box/typography styling. It
-              // carries the button *semantics* instead, so the detail view has a
-              // keyboard entry point to match the pointer one.
-              role="button"
-              tabIndex={0}
+              role="img"
               aria-label={card.work.title}
-              onKeyDown={(e) => {
-                if (e.key !== "Enter" && e.key !== " ") return;
-                e.preventDefault();
-                openDetail(card);
-              }}
               className="absolute left-1/2 top-1/2"
               style={{ transformStyle: "preserve-3d", opacity: 0 }}
             >
@@ -1013,10 +705,7 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
       </footer>
 
       {/* Formation dock */}
-      <div
-        inert={open}
-        className="pointer-events-none absolute inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-6 sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-5 sm:justify-end sm:px-0 sm:pr-6"
-      >
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 z-50 flex justify-center px-4 pb-6 sm:inset-x-auto sm:bottom-auto sm:right-0 sm:top-5 sm:justify-end sm:px-0 sm:pr-6">
         <div
           role="tablist"
           data-fm-ui
@@ -1055,198 +744,6 @@ export const Formation = ({ works }: FormationProps): ReactNode => {
           })}
         </div>
       </div>
-
-      {/* Detail — eyelid blink */}
-      {work && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label={work.title}
-          className="absolute inset-0"
-          style={{ zIndex: 5000 }}
-        >
-          {/* Click-anywhere-to-close: the image plate above this backdrop is
-              full-bleed, so it (and everything decorative inside it) has to stay
-              transparent to pointer events for the backdrop to be reachable at
-              all. The close button opts back in. */}
-          <div
-            ref={bdRef}
-            onClick={closeDetail}
-            className="absolute inset-0"
-            style={{ background: "#050505", opacity: 0 }}
-          />
-          <div className="pointer-events-none absolute inset-0 overflow-hidden">
-            <div ref={imgWrapRef} className="absolute inset-0" style={{ opacity: 0 }}>
-              <div
-                ref={imgInnerRef}
-                className="absolute inset-0"
-                style={{ transformOrigin: "center", transform: "scale(1.4)" }}
-              >
-                <div
-                  className="absolute inset-0"
-                  style={{
-                    backgroundImage: `url(${work.image})`,
-                    backgroundColor: "#0a0a0a",
-                    backgroundSize: "cover",
-                    backgroundPosition: "center",
-                    filter: "saturate(0.98) contrast(1.03)",
-                  }}
-                />
-              </div>
-            </div>
-
-            <div
-              ref={scrimRef}
-              className="pointer-events-none absolute inset-0"
-              style={{
-                opacity: 0,
-                background:
-                  "linear-gradient(90deg, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.42) 36%, rgba(0,0,0,0) 64%), linear-gradient(0deg, rgba(0,0,0,0.62) 0%, rgba(0,0,0,0) 44%)",
-              }}
-            />
-
-            <div
-              ref={detailBoxRef}
-              className="absolute text-white"
-              style={{
-                left: "6vw",
-                right: "6vw",
-                bottom: "8vh",
-                maxWidth: 760,
-              }}
-            >
-              <div
-                data-fm-reveal
-                className="mb-4 flex items-center gap-3 uppercase"
-                style={{
-                  fontFamily: MONO,
-                  fontSize: "0.72rem",
-                  letterSpacing: "0.24em",
-                  opacity: 0,
-                }}
-              >
-                <span
-                  ref={ruleRef}
-                  style={{
-                    display: "inline-block",
-                    width: 32,
-                    height: 2,
-                    background: work.accent,
-                    transformOrigin: "left center",
-                    transform: "scaleX(0)",
-                  }}
-                />
-                {work.category}
-              </div>
-
-              <div className="overflow-hidden">
-                <h2
-                  ref={titleRef}
-                  style={{
-                    fontFamily: SANS,
-                    fontWeight: 800,
-                    fontSize: "clamp(2.6rem, 6.4vw, 5.4rem)",
-                    lineHeight: 0.97,
-                    letterSpacing: "-0.04em",
-                    transform: "translateY(120%)",
-                  }}
-                >
-                  {work.title}
-                </h2>
-              </div>
-
-              <div
-                data-fm-reveal
-                className="mt-6 inline-flex items-baseline gap-3 pt-4 uppercase"
-                style={{
-                  fontFamily: MONO,
-                  fontSize: "0.62rem",
-                  letterSpacing: "0.2em",
-                  fontVariantNumeric: "tabular-nums",
-                  borderTop: "1px solid rgba(255,255,255,0.22)",
-                  opacity: 0,
-                  transform: "translateY(26px)",
-                }}
-              >
-                <span style={{ opacity: 0.55 }}>№</span>
-                <span>{detailNo}</span>
-              </div>
-            </div>
-
-            <button
-              ref={closeBtnRef}
-              data-fm-ui
-              type="button"
-              aria-label="Close"
-              onClick={closeDetail}
-              className="pointer-events-auto absolute flex items-center justify-center rounded-full text-white"
-              style={{
-                right: 20,
-                top: 20,
-                width: 44,
-                height: 44,
-                background: "rgba(255,255,255,0.12)",
-                backdropFilter: "blur(6px)",
-                WebkitBackdropFilter: "blur(6px)",
-                opacity: 0,
-              }}
-            >
-              <X className="size-5" />
-            </button>
-
-            <div
-              ref={lidTopRef}
-              className="absolute inset-x-0 top-0"
-              style={{
-                height: "51%",
-                background: "#050505",
-                transformOrigin: "top",
-                transform: "scaleY(0)",
-                zIndex: 20,
-              }}
-            />
-            <div
-              ref={lidBotRef}
-              className="absolute inset-x-0 bottom-0"
-              style={{
-                height: "51%",
-                background: "#050505",
-                transformOrigin: "bottom",
-                transform: "scaleY(0)",
-                zIndex: 20,
-              }}
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Liquid-glass cursor */}
-      <div
-        ref={glassRef}
-        aria-hidden
-        style={{
-          position: "absolute",
-          // `relayout` owns this — it flips to `block` only where the lens is
-          // both wanted (fine pointer, wide enough root) and animated.
-          display: "none",
-          left: 0,
-          top: 0,
-          zIndex: 6000,
-          width: 56,
-          height: 56,
-          borderRadius: 9999,
-          pointerEvents: "none",
-          opacity: 0,
-          willChange: "transform",
-          transform: "translate3d(-100px, -100px, 0)",
-          backdropFilter: `url(#${filterId}) saturate(1.5) brightness(1.05)`,
-          WebkitBackdropFilter: `url(#${filterId}) saturate(1.5) brightness(1.05)`,
-          background:
-            "radial-gradient(circle at 34% 28%, rgba(255,255,255,0.5), rgba(255,255,255,0.04) 44%, rgba(255,255,255,0) 70%)",
-          boxShadow:
-            "inset 0 1px 2px rgba(255,255,255,0.85), inset 0 0 0 1px rgba(255,255,255,0.3), inset 0 -12px 18px rgba(0,0,0,0.16), inset 0 12px 18px rgba(255,255,255,0.12), 0 12px 30px -8px rgba(0,0,0,0.4)",
-        }}
-      />
     </section>
   );
 };

--- a/content/formation/meta.json
+++ b/content/formation/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "Formation",
-  "description": "Sixteen photo cards regroup between four spatial formations — a solved ellipse, an arc conveyor, a tilted ring and a swelling orbit — while a refracting glass lens tracks the cursor and clicking a card blinks it open behind closing eyelids.",
+  "description": "Sixteen photo cards regroup between four spatial formations — a solved ellipse, an arc conveyor, a tilted ring and a swelling orbit — and scrub under drag or wheel with a parallax lean that follows the cursor.",
   "addedAt": "2026-07-18",
   "coverUrl": "https://zmdrwswxugswzmcokvff.supabase.co/storage/v1/object/public/uicapsule/formation/formation.mp4",
   "coverType": "video",

--- a/content/formation/package.json
+++ b/content/formation/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "gsap": "^3.15.0",
-    "lucide-react": "^1.35.0",
     "react": "catalog:",
     "react-dom": "catalog:"
   },

--- a/content/formation/preview.tsx
+++ b/content/formation/preview.tsx
@@ -9,98 +9,66 @@ const rootUrl =
 const works: Work[] = [
   {
     title: "Vantage",
-    category: "Art Direction",
-    accent: "#e8b15a",
     image: `${rootUrl}/vista.jpg`,
   },
   {
     title: "Mirror",
-    category: "Installation",
-    accent: "#7b9e6b",
     image: `${rootUrl}/mirror.jpg`,
   },
   {
     title: "Cosmos",
-    category: "Title Sequence",
-    accent: "#6f7cf0",
     image: `${rootUrl}/cosmos.jpg`,
   },
   {
     title: "Current",
-    category: "Motion",
-    accent: "#9b7cf0",
     image: `${rootUrl}/current.jpg`,
   },
   {
     title: "Threshold",
-    category: "Concept",
-    accent: "#ff9a4d",
     image: `${rootUrl}/portal.jpg`,
   },
   {
     title: "Hollow",
-    category: "Photography",
-    accent: "#e0a85a",
     image: `${rootUrl}/valley.jpg`,
   },
   {
     title: "Ascent",
-    category: "Campaign",
-    accent: "#f0b84a",
     image: `${rootUrl}/ascent.jpg`,
   },
   {
     title: "Array",
-    category: "Brand Film",
-    accent: "#4bb98a",
     image: `${rootUrl}/array.jpg`,
   },
   {
     title: "Meridian",
-    category: "Travel",
-    accent: "#d8a967",
     image: `${rootUrl}/giza.jpg`,
   },
   {
     title: "Rift",
-    category: "Key Art",
-    accent: "#e0503a",
     image: `${rootUrl}/rift.jpg`,
   },
   {
     title: "Overlook",
-    category: "Editorial",
-    accent: "#c0895a",
     image: `${rootUrl}/overlook.jpg`,
   },
   {
     title: "Event Horizon",
-    category: "Title Design",
-    accent: "#f0a24a",
     image: `${rootUrl}/horizon.jpg`,
   },
   {
     title: "Archipelago",
-    category: "Aerial",
-    accent: "#3aa0c0",
     image: `${rootUrl}/archipelago.jpg`,
   },
   {
     title: "Crest",
-    category: "Concept",
-    accent: "#e8a24a",
     image: `${rootUrl}/crest.jpg`,
   },
   {
     title: "Ridge",
-    category: "Photography",
-    accent: "#6ea35a",
     image: `${rootUrl}/ridge.jpg`,
   },
   {
     title: "Fathom",
-    category: "Editorial",
-    accent: "#3a7ac0",
     image: `${rootUrl}/fathom.jpg`,
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -683,9 +683,6 @@ importers:
       gsap:
         specifier: ^3.15.0
         version: 3.15.0
-      lucide-react:
-        specifier: ^1.35.0
-        version: 1.35.0(react@19.2.8)
       react:
         specifier: 'catalog:'
         version: 19.2.8


### PR DESCRIPTION
Formation: remove the liquid-glass lens cursor and the tap-to-open eyelid detail overlay. Keep drag/wheel scrub, the four formations, hover zoom, parallax. Cover re-recorded and replaced in Supabase.

Also: cover-video skill notes that `supabase storage cp` never overwrites (409) and `rm` needs `--yes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018VA26TiQxgSihowTrk6j5n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the liquid-glass lens cursor and the tap-to-open eyelid detail overlay from Formation; the carousel now uses the native cursor and keeps drag/wheel scrub, the four formations, hover zoom, and parallax.

- Card data trims to title and image, dropping `category`, `accent`, and the `lucide-react` dependency.
- The detail overlay's keyboard access (Enter/Space to open, Escape to close) is removed with it.
- Re-recorded the cover video; `cover-video` skill now notes `supabase storage cp` fails with 409 on existing objects and `rm --yes` must run first.

<sup>Written for commit d1ae72d75f91a4f4522797a25b54d280e09bf16d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

