### PR TITLE
Drop dead lint directives, make install label follow copied state

### DIFF
--- a/apps/web/src/app/(main)/(content)/_components/aside.tsx
+++ b/apps/web/src/app/(main)/(content)/_components/aside.tsx
@@ -208,7 +208,7 @@ const Aside = ({ contentComponent }: AsideProps) => {
             <div className="flex justify-center">
               <button
                 type="button"
-                aria-label="Copy the shadcn install command"
+                aria-label={copied ? "Copied to clipboard" : "Copy the shadcn install command"}
                 className="text-muted-foreground grid text-xs"
                 onClick={handleInstallClick}
               >

--- a/content/emerald-template/_components/infinite-loop.tsx
+++ b/content/emerald-template/_components/infinite-loop.tsx
@@ -60,7 +60,6 @@ export const InfiniteLooper = ({
       <div className={cn("flex w-fit justify-center", className)} ref={innerRef}>
         {Array.from({ length: looperInstances }, (_, index) => (
           <div
-            // oxlint-disable-next-line react/no-array-index-key -- Identical animation copies keep fixed positions; only trailing copies are added or removed.
             key={index}
             className={cn("flex w-max", animating && "animate-slide-across")}
             style={{

--- a/packages/ui/src/components/code-block.tsx
+++ b/packages/ui/src/components/code-block.tsx
@@ -438,7 +438,6 @@ const CodeBlockFallback = ({ children, ...props }: CodeBlockFallbackProps) => (
           ?.toString()
           .split("\n")
           .map((line, lineNumber) => (
-            // eslint-disable-next-line react/no-array-index-key -- Lines are positional, stateless source text.
             <span className="line" key={lineNumber}>
               {line}
             </span>


### PR DESCRIPTION
Two loose ends from #118.

- \`react/no-array-index-key\` is off in the ultracite react preset, so the disable comments in \`code-block.tsx\` and \`infinite-loop.tsx\` were dead and warned on every lint run. Removed.
- The install button's \`aria-label\` was static; it now reads "Copied to clipboard" while in the copied state so screen readers get the same feedback as the visible label.

\`pnpm verify\` green, lint has zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes two dead lint directives that were triggering warnings on every lint run, and makes the install button's `aria-label` reflect the copied state so screen readers announce the same feedback as the visible label.

<sup>Written for commit 92629d349c8dae9114b852c27e94034ac16f62a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

