### PR TITLE
Type next.config as TypeScript

### DIFF
--- a/.claude/skills/cover-video/SKILL.md
+++ b/.claude/skills/cover-video/SKILL.md
@@ -52,7 +52,7 @@ agent-browser --session covers screenshot <scratch>/stage.png   # Read it: layou
 ```
 
 Coordinates measured on `stage.png` are the coordinates the recording sees — same tab, same
-viewport. `next.config.js` sets `devIndicators: false`, so there is no dev badge to strip.
+viewport. `next.config.ts` sets `devIndicators: false`, so there is no dev badge to strip.
 
 If the component is small in a 1600×900 frame (a pill, a toggle), scale the preview's inner
 block before measuring — `transform: scale(1.8)` on `main`'s first child, origin center —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ Web is the only surface. There is no mobile, desktop, or extension target.
   is the local one.
 - Env vars read at build time must be listed in `turbo.json` `globalEnv`, or turbo's strict
   env mode strips them from the task with no error. `NEXT_PUBLIC_SUPABASE_URL` was missing
-  from it until recently: `next.config.js` reads it to build `images.remotePatterns`, so
+  from it until recently: `next.config.ts` reads it to build `images.remotePatterns`, so
   without it that list is empty and `next/image` rejects every Supabase-hosted cover. Not
   yet load-bearing — every cover in the repo today is `coverType: "video"` (28 of 40 slugs;
   the other 12 have no cover), and video bypasses `next/image` — but it bites the first time

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,9 @@
-import { readdirSync, existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import path from "node:path";
+import type { NextConfig } from "next";
+
+type ImageConfig = NonNullable<NextConfig["images"]>;
+type RemotePatterns = NonNullable<ImageConfig["remotePatterns"]>;
 
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -18,9 +22,8 @@ const getContentPackages = () => {
   }
 };
 
-const getRemotePatterns = () => {
-  /** @type {import("next/dist/shared/lib/image-config").RemotePattern[]} */
-  const remotePatterns = [];
+const getRemotePatterns = (): RemotePatterns => {
+  const remotePatterns: RemotePatterns = [];
 
   if (SUPABASE_URL) {
     const { hostname } = new URL(SUPABASE_URL);
@@ -49,8 +52,7 @@ const getRemotePatterns = () => {
 
 const transpilePackages = ["@repo/api", "@repo/db", "@repo/ui", ...getContentPackages()];
 
-/** @type {import("next").NextConfig} */
-const config = {
+const config: NextConfig = {
   /** next dev rewrites AGENTS.md/CLAUDE.md when it detects an agent; we own those files */
   agentRules: false,
   cacheComponents: true,


### PR DESCRIPTION
`apps/web/next.config.js` was already ESM but typed only through a JSDoc `@type` annotation, and reached into `next/dist/shared/lib/image-config` for the remote-pattern type. Moved with `git mv` so history follows.

- `next.config.js` → `next.config.ts`, `const config: NextConfig`
- `RemotePatterns` derived from `NextConfig["images"]` rather than a deep `next/dist` import
- `next.config.js` references updated in `AGENTS.md` and `.claude/skills/cover-video/SKILL.md`

No `typescript.ignoreBuildErrors` / `eslint.ignoreDuringBuilds` was set, so nothing to unmask — the build already typechecks and stays green.

`pnpm verify` (typecheck · lint · format · test · build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `apps/web/next.config.js` to `next.config.ts` and adds `NextConfig` typing, replacing JSDoc and a deep Next.js internal import with types derived from the public config type. Runtime behavior stays unchanged while config changes become type-safe and less dependent on Next.js internals.

- Updates references in `AGENTS.md` and the cover-video skill documentation.
- `pnpm verify` passes, including typecheck, lint, format, test, and build.

<sup>Written for commit e6d875087c92e1751a1a666a0f25bde4753d4a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

