### PR TITLE
Guard the ignorePatterns spread in oxlint config

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,7 +7,7 @@ import react from "ultracite/oxlint/react";
 export default defineConfig({
   extends: [core, react, antiSlop],
   ignorePatterns: [
-    ...core.ignorePatterns,
+    ...(core.ignorePatterns ?? []),
     "dist-electron",
     ".expo",
     ".wxt",


### PR DESCRIPTION
`ultracite` types `OxlintConfig.ignorePatterns` as `string[] | undefined`, so spreading it bare is unsound:

```
oxlint.config.ts: error TS2488: Type 'string[] | undefined' must have a '[Symbol.iterator]()' method that returns an iterator.
```

Latent here rather than live: neither root tsconfig reaches it — `tsconfig.scripts.json` includes only `scripts/**/*.ts` and `tsconfig.content.json` has an empty `include`, so `tsc --listFiles` finds 0 hits for `oxlint.config.ts`. The sibling eve repos do include it and already carry this guard — one of them hit the error on a fresh CI checkout.

At runtime `core.ignorePatterns` is a 53-item array, so `?? []` never fires: behavior is identical, and the file stays sound if it's ever added to a program.

Verified: `oxlint` clean (0 errors, 0 warnings), `oxfmt --check` clean, `turbo run typecheck --force`, `typecheck:scripts` and `typecheck:content` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards the `ignorePatterns` spread in `oxlint.config.ts` so TypeScript no longer raises TS2488 when the file is included in a program.

`ultracite` types `OxlintConfig.ignorePatterns` as `string[] | undefined`, so the bare spread is unsound. The error is latent here because the file isn't in any tsconfig program, but sibling eve repos include it and CI caught it there. At runtime the array always exists, so behavior is unchanged.

<sup>Written for commit be036f4e3ca1d5185f4a6c279f4043bcab670953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

