### PR TITLE
Move content assets from R2 to the uicapsule-assets Vercel Blob store

### DIFF
--- a/.claude/skills/build-content/SKILL.md
+++ b/.claude/skills/build-content/SKILL.md
@@ -161,4 +161,4 @@ finishes; the gif renders immediately.)
 - Delete scratch mp4/gif/frames/batch files.
 - Report the PR URL and your take on the component.
 - Offer, don't do: gallery cover via the `cover-video` skill (separate 1600×900 mp4
-  pipeline + R2 upload), typically after the PR merges.
+  pipeline + Blob upload), typically after the PR merges.

--- a/.claude/skills/build-requests/SKILL.md
+++ b/.claude/skills/build-requests/SKILL.md
@@ -12,8 +12,8 @@ description: >
 
 Queue → claim → build-content → cover-video → PR that closes the issue.
 
-Run this from a clean `main` with `pnpm dev:web` reachable on :3000 and `CLOUDFLARE_API_TOKEN`
-in the environment (cover-video uploads via wrangler). It is designed to be scheduled locally, e.g.
+Run this from a clean `main` with `pnpm dev:web` reachable on :3000 and the Vercel CLI
+linked to the project (cover-video uploads via `vercel blob put`). It is designed to be scheduled locally, e.g.
 `claude -p "/build-requests"` from cron or launchd once a day.
 
 ## 1. Queue
@@ -64,7 +64,7 @@ build, verify, record, PR). Differences:
 
 Run `../cover-video/SKILL.md` on the same branch before opening the PR, so the PR
 ships with `cover` already wired. Follow it exactly — dedicated
-`--session covers`, native `.mp4` at `--fps 60`, 1600×900, frame-check, R2
+`--session covers`, native `.mp4` at `--fps 60`, 1600×900, frame-check, Blob
 upload, gallery confirm. Every shortcut it warns about has already cost a take.
 
 ## 5. Done gate — every line must pass before `gh pr create`

--- a/.claude/skills/cover-video/SKILL.md
+++ b/.claude/skills/cover-video/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cover-video
-description: Record a cover video for a content component, verify it looks right, upload it to R2, and wire it into meta.json. Use when asked to generate/update a component's cover, preview video, or gallery thumbnail.
+description: Record a cover video for a content component, verify it looks right, upload it to Vercel Blob, and wire it into meta.json. Use when asked to generate/update a component's cover, preview video, or gallery thumbnail.
 ---
 
 # Cover Video
@@ -144,20 +144,20 @@ Read every frame as an image and check ALL of:
 
 ## 6. Upload
 
-Covers live in the `uicapsule-assets` R2 bucket, keyed `<slug>/<slug>.mp4`. Upload with
-wrangler (needs `CLOUDFLARE_API_TOKEN` in the environment, or `wrangler login`):
+Covers live in the `uicapsule-assets` Vercel Blob store, keyed `<slug>/<slug>.mp4`. Upload
+with the Vercel CLI from the repo root (the project is linked; the store's token is in
+`.env.local` via `vercel env pull`):
 
 ```bash
-npx wrangler@latest r2 object put "uicapsule-assets/<slug>/<slug>.mp4" \
-  --file <slug>.mp4 --content-type video/mp4
+vercel blob put <slug>.mp4 --pathname "<slug>/<slug>.mp4" --content-type video/mp4 \
+  --access public --add-random-suffix false --allow-overwrite true
 curl -s -o /dev/null -w "%{http_code} %{content_type}" \
   "$NEXT_PUBLIC_ASSETS_URL/<slug>/<slug>.mp4"
 # expect: 200 video/mp4
 ```
 
-`put` overwrites silently, so replacing a cover is the same command. The public URL sits
-behind Cloudflare's cache — a replaced cover can serve stale for a while; mention that when
-overwriting.
+`--allow-overwrite` means replacing a cover is the same command. The public URL sits behind
+Vercel's CDN — a replaced cover can serve stale for a while; mention that when overwriting.
 
 ## 7. Wire up + confirm
 

--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,12 @@ BETTER_AUTH_SECRET=""
 # Optional local origin override; match the dev server port.
 BETTER_AUTH_URL="http://localhost:3000"
 
-# Public origin of the `uicapsule-assets` R2 bucket (covers, illustrations). The value
+# Public origin of the `uicapsule-assets` Vercel Blob store (covers, illustrations). The value
 # below is the real one — every content/*/meta.json `cover` key resolves against it.
 # Required: apps/web/src/lib/assets.ts throws without it, and next.config.ts builds
 # images.remotePatterns from it. Keep it listed in turbo.json globalEnv too, or turbo's
 # strict env mode strips it from the build with no error.
-NEXT_PUBLIC_ASSETS_URL="https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev"
+NEXT_PUBLIC_ASSETS_URL="https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com"
 
 # Password reset delivery. Set both in production; use a verified Resend sender.
 RESEND_API_KEY=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       TURSO_DATABASE_URL: http://127.0.0.1:8080
       TURSO_AUTH_TOKEN: ""
       BETTER_AUTH_SECRET: uicapsule-ci-only-secret-for-static-checks
-      NEXT_PUBLIC_ASSETS_URL: https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev
+      NEXT_PUBLIC_ASSETS_URL: https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com
     steps:
       - uses: actions/checkout@v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ pnpm check:content        # fail if any content/<slug> is not loadable
 Two committed skills own the full lifecycles and both shell out to `agent-browser`:
 
 - `.claude/skills/build-content` — idea → scaffold → build → record → PR
-- `.claude/skills/cover-video` — record, verify, upload to R2, wire into `meta.json`
+- `.claude/skills/cover-video` — record, verify, upload to Blob, wire into `meta.json`
 - `.claude/skills/build-requests` — drain `ready`-labelled request issues through both of
   the above, one PR per issue, `Closes #n`. Meant for a local daily schedule.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ does not prove delivery. Reset tokens expire after one hour and revoke existing 
 
 - **auth + oRPC are kept.** One procedure, zero callers, deliberately retained for a future
   feature. Make them correct; don't propose deleting them.
-- **Assets live in the `uicapsule-assets` R2 bucket.** Covers, illustrations and other
+- **Assets live in the `uicapsule-assets` Vercel Blob store.** Covers, illustrations and other
   content media resolve against `NEXT_PUBLIC_ASSETS_URL`; `meta.json` stores bucket keys,
   never URLs.
 - **Vercel builds on every push — deliberately. Do not add build-skipping.** Both Vercel's

--- a/apps/web/src/lib/assets.ts
+++ b/apps/web/src/lib/assets.ts
@@ -6,7 +6,7 @@ if (!assetsUrl) {
   );
 }
 
-/** Public URL of a key in the `uicapsule-assets` R2 bucket. */
+/** Public URL of a key in the `uicapsule-assets` Vercel Blob store. */
 export const assetUrl = (key: string) => `${assetsUrl}/${key}`;
 
 export type CoverType = "image" | "video";

--- a/apps/web/src/lib/content/content-schema.ts
+++ b/apps/web/src/lib/content/content-schema.ts
@@ -10,8 +10,8 @@ const tagsSchema = z
   });
 
 const linkSchema = z.object({ label: z.string().min(1), url: z.url() });
-// A key in the assets bucket (`<slug>/<file>.<ext>`), never a URL: the host is
-// resolved by the app so the bucket can move without touching every meta.json.
+// A key in the assets store (`<slug>/<file>.<ext>`), never a URL: the host is
+// resolved by the app so the store can move without touching every meta.json.
 const coverKeySchema = z.string().regex(/^[a-z0-9-]+\/[\w.-]+\.(?:mp4|webm|png|jpe?g|webp|gif)$/u, {
   message: "cover must be a bucket key like <slug>/<slug>.mp4",
 });

--- a/content/background-pixel-stars/preview.tsx
+++ b/content/background-pixel-stars/preview.tsx
@@ -3,7 +3,7 @@
 import { BackgroundPixelStars } from "./background-pixel-stars";
 
 const Preview = () => (
-  <div className="h-dvh w-dvw bg-black bg-[url('https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/background-pixel-stars/bg.png')] bg-[size:10px]">
+  <div className="h-dvh w-dvw bg-black bg-[url('https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/background-pixel-stars/bg.png')] bg-[size:10px]">
     <BackgroundPixelStars />
   </div>
 );

--- a/content/card-stack/preview.tsx
+++ b/content/card-stack/preview.tsx
@@ -2,7 +2,7 @@
 
 import { CardStack } from "./card-stack";
 
-const rootUrl = "https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/card-stack-1";
+const rootUrl = "https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/card-stack-1";
 
 const cards = [
   { alt: "UI Capsule", href: "https://uicapsule.com", src: `${rootUrl}/uic.webp` },

--- a/content/carousel-3d/preview.tsx
+++ b/content/carousel-3d/preview.tsx
@@ -2,7 +2,7 @@
 
 import { ImageCarousel, ImageCarouselCanvas } from "./carousel-3d";
 
-const rootUrl = "https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/carousel-3d";
+const rootUrl = "https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/carousel-3d";
 
 const cards = [
   { src: `${rootUrl}/1.webp` },

--- a/content/emerald-template/_components/hero-section.tsx
+++ b/content/emerald-template/_components/hero-section.tsx
@@ -52,7 +52,7 @@ export const HeroSection = () => (
         playsInline
         className="pointer-events-none absolute inset-0 w-full translate-y-10 [mask-image:linear-gradient(transparent_10%,black,transparent)] opacity-50 mix-blend-lighten hue-rotate-[250deg]"
       >
-        <source src="https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/emerald-template/home-hero-bg.mov" />
+        <source src="https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/emerald-template/home-hero-bg.mov" />
       </video>
       <HeroExample />
     </div>

--- a/content/emerald-template/_components/source-icon.tsx
+++ b/content/emerald-template/_components/source-icon.tsx
@@ -1,7 +1,7 @@
 import type { ComponentType, SVGProps } from "react";
 import { cn } from "cn";
 
-const ICON_ASSET_BASE = "https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/emerald-template";
+const ICON_ASSET_BASE = "https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/emerald-template";
 
 const shellClassName =
   "inline-flex justify-center rounded-full border border-dashed border-zinc-700 bg-zinc-900 p-3 text-white";

--- a/content/formation/preview.tsx
+++ b/content/formation/preview.tsx
@@ -3,7 +3,7 @@
 import type { Work } from "./formation-poses";
 import { Formation } from "./formation";
 
-const rootUrl = "https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/formation";
+const rootUrl = "https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/formation";
 
 const works: Work[] = [
   {

--- a/content/infinite-grid/preview.tsx
+++ b/content/infinite-grid/preview.tsx
@@ -18,7 +18,7 @@ const Cell = ({ gridIndex }: GridItemConfig) => (
     <img
       alt=""
       className="pointer-events-none size-20"
-      src={`https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/illustrations/blueprint/%20${(gridIndex % 100) + 1}.svg`}
+      src={`https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/illustrations/blueprint/%20${(gridIndex % 100) + 1}.svg`}
     />
   </motion.div>
 );

--- a/content/lookbook-camera/lookbook-data.ts
+++ b/content/lookbook-camera/lookbook-data.ts
@@ -10,7 +10,8 @@
  * `look-figure.tsx` can crop any piece out of any look with one set of boxes.
  */
 
-const LOOK_IMAGE_BASE = "https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/lookbook-camera/looks";
+const LOOK_IMAGE_BASE =
+  "https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/lookbook-camera/looks";
 
 export type ItemCategory = "Outerwear" | "Knitwear" | "Tops" | "Trousers" | "Skirt" | "Footwear";
 

--- a/content/snail-timer/snail-timer.css
+++ b/content/snail-timer/snail-timer.css
@@ -69,7 +69,7 @@
 .snail-timer__dust {
   width: 197px;
   height: 66px;
-  background-image: url("https://pub-327ea719340342d3a3d5c5aa7f979e3a.r2.dev/snail-timer/dust.svg");
+  background-image: url("https://d24l2zb4cwkekfpl.public.blob.vercel-storage.com/snail-timer/dust.svg");
   background-size: 5910px 67px;
   animation: snail-dust var(--snail-dust-duration) steps(29) infinite forwards;
   transform: translate(-20px, 10px);


### PR DESCRIPTION
Follows #127. R2's public URL is dev-only (rate-limited, no cache) and a custom domain would force uicapsule.com onto Cloudflare DNS, so assets move to a Vercel Blob store (`uicapsule-assets`). Blob data transfer sits inside the flat-rate CDN allowance.

- `meta.json` keys and the `NEXT_PUBLIC_ASSETS_URL` resolver are unchanged; only the origin moves.
- 8 self-contained content packages point at the new origin.
- `cover-video` skill uploads with `vercel blob put --allow-overwrite`; `build-requests` gate updated.
- CI, `.env.example`, AGENTS/CLAUDE wording updated.

All 413 objects are uploaded key-for-key and every URL verified 200 before this PR. Vercel env already points at the store. R2 bucket `uicapsule-assets` is deleted after this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017jTaKdDRFsUgZbcUakSfDc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves content assets from R2's dev-only public URL to the `uicapsule-assets` Vercel Blob store so delivery is no longer rate-limited and data transfer sits inside the flat-rate CDN allowance.

- `meta.json` keys and the `NEXT_PUBLIC_ASSETS_URL` resolver are unchanged; only the origin host moves.
- All 8 content packages now point at the new Blob store origin.
- The `cover-video` skill uploads with `vercel blob put --allow-overwrite` instead of wrangler.
- All 413 objects were uploaded key-for-key and every URL verified 200 before this PR.
- The R2 bucket `uicapsule-assets` is deleted after this ships.

<sup>Written for commit 817300dde30de829708f58c20a5eff07de15a95c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/uicapsule/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

